### PR TITLE
PyCuClarabel

### DIFF
--- a/src/gpucones/augment_socp.jl
+++ b/src/gpucones/augment_socp.jl
@@ -1,153 +1,127 @@
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
+from scipy.sparse import csr_matrix, vstack
 
-function count_soc(cone, size_soc)
+@njit
+def count_soc(cone, size_soc):
+    numel_cone = cone.shape[0]
+    assert numel_cone > size_soc
 
-    numel_cone = Clarabel.nvars(cone)
-    @assert(numel_cone > size_soc)
-        
     num_socs = 1
-    numel_cone -= size_soc-1
+    numel_cone -= size_soc - 1
 
-    while (numel_cone > size_soc-1)
-        numel_cone -= size_soc-2
+    while numel_cone > size_soc - 1:
+        numel_cone -= size_soc - 2
         num_socs += 1
-    end
 
     num_socs += 1
 
-    return num_socs, numel_cone+1
-end
+    return num_socs, numel_cone + 1
 
-#augment At,b for a large soc
-function augment_data(At0,
-    b0::Vector{T},
-    rng_row,size_soc,num_soc,last_size,augx_idx) where {T}
-
-    At = At0[:,rng_row]
+@njit
+def augment_data(At0, b0, rng_row, size_soc, num_soc, last_size, augx_idx):
+    At = At0[:, rng_row]
     b = b0[rng_row]
-    (n,m) = size(At)
+    n, m = At.shape
     reduce_soc = size_soc - 2
-    @assert(reduce_soc > 0)
+    assert reduce_soc > 0
 
-    bnew = sizehint!(T[],m + 2*(num_soc-1))
-    conenew = sizehint!(Clarabel.SupportedCone[],num_soc)
+    bnew = np.empty(m + 2 * (num_soc - 1), dtype=At0.dtype)
+    conenew = []
 
-    Atnew = At[:,1]
-    push!(bnew,b[1])
-    idx = 1             #complete index
-    for i in 1:num_soc
-        if i == num_soc
-            rng = idx+1:idx+last_size-1
-            Atnew = hcat(Atnew,At[:,rng])
-            @views append!(bnew,b[rng])
-            push!(conenew, Clarabel.SecondOrderConeT(last_size))
-        else
-            rng = idx+1:idx+reduce_soc
-            Atnew = hcat(Atnew,At[:,rng])
-            @views append!(bnew,b[rng])
-            push!(conenew, Clarabel.SecondOrderConeT(size_soc))
+    Atnew = At[:, :1]
+    bnew[0] = b[0]
+    idx = 1  # complete index
+    for i in range(num_soc):
+        if i == num_soc - 1:
+            rng = slice(idx + 1, idx + last_size)
+            Atnew = np.hstack((Atnew, At[:, rng]))
+            bnew[idx + 1:idx + last_size] = b[rng]
+            conenew.append(last_size)
+        else:
+            rng = slice(idx + 1, idx + reduce_soc + 1)
+            Atnew = np.hstack((Atnew, At[:, rng]))
+            bnew[idx + 1:idx + reduce_soc + 1] = b[rng]
+            conenew.append(size_soc)
 
             idx += reduce_soc
             augx_idx += 1
-            Atnew = hcat(Atnew,sparse([augx_idx, augx_idx],[1,2],[-1,-1],n,2))
-            @views append!(bnew,[0,0])
-        end
-    end
+            Atnew = np.hstack((Atnew, csr_matrix(([-1, -1], ([augx_idx, augx_idx], [0, 1])), shape=(n, 2)).toarray()))
+            bnew[idx + 1:idx + 3] = [0, 0]
 
     return Atnew, bnew, conenew, augx_idx
-end
 
-function augment_A_b_soc(
-    cones::Vector{SupportedCone},
-    P::AbstractMatrix{T},
-    q::Vector{T},
-    A::AbstractMatrix{T},
-    b::Vector{T},
-    size_soc::Int64,
-    num_socs::Vector{Int}, 
-    last_sizes::Vector{Int}, 
-    soc_indices::Vector{Int}, 
-    soc_starts::Vector{Int}
-) where {T}
+@njit
+def augment_A_b_soc(cones, P, q, A, b, size_soc, num_socs, last_sizes, soc_indices, soc_starts):
+    m, n = A.shape
 
-    (m,n) = size(A)
-    
-    extra_dim = sum(num_socs) - length(num_socs)    #Additional dimensionality for x
+    extra_dim = np.sum(num_socs) - len(num_socs)  # Additional dimensionality for x
 
-    At = vcat(SparseMatrixCSC(A'), spzeros(extra_dim,m))        #May be costly, but more efficient to add rows to a SparseCSR matrix
-    bnew = sizehint!(T[],m + 2*extra_dim)
-    conesnew = sizehint!(Clarabel.SupportedCone[],length(cones) + extra_dim)
+    At = vstack([csr_matrix(A.T), csr_matrix((extra_dim, m))])  # May be costly, but more efficient to add rows to a SparseCSR matrix
+    bnew = np.empty(m + 2 * extra_dim, dtype=A.dtype)
+    conesnew = []
 
-    Atnew = spzeros(n+extra_dim,0)
+    Atnew = csr_matrix((n + extra_dim, 0))
 
     start_idx = 0
     end_idx = 0
     cone_idx = 0
-    augx_idx = n    #the pointer to the auxiliary x used so far
-    
-    for (i,ind) in enumerate(soc_indices)
+    augx_idx = n  # the pointer to the auxiliary x used so far
 
-        @views append!(conesnew, cones[cone_idx+1:ind-1])
+    for i, ind in enumerate(soc_indices):
+        conesnew.extend(cones[cone_idx:ind])
 
-        numel_cone = Clarabel.nvars(cones[ind])
+        numel_cone = cones[ind]
 
         end_idx = soc_starts[i]
 
-        rng = start_idx+1:end_idx
-        @views Atnew = hcat(Atnew, At[:,rng])
-        @views append!(bnew,b[rng])
+        rng = slice(start_idx, end_idx)
+        Atnew = vstack([Atnew, At[:, rng]])
+        bnew[start_idx:end_idx] = b[rng]
 
         start_idx = end_idx
         end_idx += numel_cone
-        rng_cone = start_idx+1:end_idx
+        rng_cone = slice(start_idx, end_idx)
 
-        Ati,bi,conesi,augx_idx = augment_data(At, b, rng_cone,size_soc,num_socs[i],last_sizes[i],augx_idx)        #augment the current large soc
+        Ati, bi, conesi, augx_idx = augment_data(At, b, rng_cone, size_soc, num_socs[i], last_sizes[i], augx_idx)  # augment the current large soc
 
-        Atnew = hcat(Atnew, Ati)
-        append!(bnew,bi)
-        append!(conesnew,conesi)
+        Atnew = vstack([Atnew, csr_matrix(Ati)])
+        bnew[start_idx:end_idx] = bi
+        conesnew.extend(conesi)
 
         start_idx = end_idx
         cone_idx = ind
-    end
-    
-    if (cone_idx< length(cones))
-        @views Atnew = hcat(Atnew, At[:,start_idx+1:end])
-        @views append!(bnew,b[start_idx+1:end])
-        @views append!(conesnew, cones[cone_idx+1:end])
-    end
 
-    Pnew = hcat(vcat(P,spzeros(extra_dim,n)),spzeros(n+extra_dim,extra_dim))
-    return Pnew,vcat(q,zeros(extra_dim)),SparseMatrixCSC(Atnew'), bnew, conesnew
-end
+    if cone_idx < len(cones):
+        Atnew = vstack([Atnew, At[:, start_idx:]])
+        bnew[start_idx:] = b[start_idx:]
+        conesnew.extend(cones[cone_idx:])
 
-function expand_soc(
-    cones::Vector{SupportedCone},
-    size_soc::Int64
-)
+    Pnew = vstack([csr_matrix(P), csr_matrix((extra_dim, n))])
+    Pnew = vstack([Pnew, csr_matrix((n + extra_dim, extra_dim))])
+    return Pnew.toarray(), np.hstack([q, np.zeros(extra_dim)]), Atnew.toarray().T, bnew, conesnew
+
+@njit
+def expand_soc(cones, size_soc):
     n_large_soc = 0
-    soc_indices = sizehint!(Int[],length(cones))            #Indices of large second-order cones 
-    soc_starts = sizehint!(Int[],length(cones))          #Starting index of each large second-order cone 
-    num_socs = sizehint!(Int[],length(cones))
-    last_sizes = sizehint!(Int[],length(cones))      #Size of the last expanded second-order cones 
+    soc_indices = []
+    soc_starts = []
+    num_socs = []
+    last_sizes = []
 
     cones_dim = 0
-    for (i,cone) in enumerate(cones)
-        numel_cone = Clarabel.nvars(cone)
-        if isa(cone,Clarabel.SecondOrderConeT) && numel_cone > size_soc
-            append!(soc_indices, i)
-            append!(soc_starts, cones_dim)
+    for i, cone in enumerate(cones):
+        numel_cone = cone
+        if numel_cone > size_soc:
+            soc_indices.append(i)
+            soc_starts.append(cones_dim)
 
-            num_soc, last_size = count_soc(cone,size_soc)
-            append!(num_socs, num_soc)
-            append!(last_sizes, last_size)
+            num_soc, last_size = count_soc(cone, size_soc)
+            num_socs.append(num_soc)
+            last_sizes.append(last_size)
             n_large_soc += 1
-        end
 
         cones_dim += numel_cone
-    end
-
-    resize!(num_socs,n_large_soc)
-    resize!(last_sizes,n_large_soc)
 
     return num_socs, last_sizes, soc_indices, soc_starts
-end

--- a/src/gpucones/compositecone_type_gpu.jl
+++ b/src/gpucones/compositecone_type_gpu.jl
@@ -1,173 +1,70 @@
-using CUDA, CUDA.CUSPARSE
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
 
-# -------------------------------------
-# collection of cones for composite
-# operations on a compound set, including
-# conewise scaling operations
-# -------------------------------------
+class CompositeConeGPU:
+    def __init__(self, cpucones):
+        self.cones = cpucones.cones
+        self.type_counts = cpucones.type_counts
+        self._is_symmetric = cpucones._is_symmetric
 
-struct CompositeConeGPU{T} <: AbstractCone{T}
-    #YC: redundant CPU data, need to be removed later
-    cones::AbstractVector{AbstractCone{T}}  
+        self.n_zero = self.type_counts.get('ZeroCone', 0)
+        self.n_nn = self.type_counts.get('NonnegativeCone', 0)
+        self.n_linear = self.n_zero + self.n_nn
+        self.n_soc = self.type_counts.get('SecondOrderCone', 0)
+        self.n_exp = self.type_counts.get('ExponentialCone', 0)
+        self.n_pow = self.type_counts.get('PowerCone', 0)
+        self.n_psd = self.type_counts.get('PSDTriangleCone', 0)
 
-    #count of each cone type
-    type_counts::Dict{Type,Cint}
+        self.idx_eq = [i for i in range(self.n_linear) if isinstance(self.cones[i], ZeroCone)]
+        self.idx_inq = [i for i in range(self.n_linear) if not isinstance(self.cones[i], ZeroCone)]
 
-    #overall size of the composite cone
-    numel::Cint
-    degree::Cint
+        self.numel = sum(cone.numel() for cone in self.cones)
+        self.degree = sum(cone.degree() for cone in self.cones)
 
-    #range views
-    rng_cones::AbstractVector{UnitRange{Cint}}
-    rng_blocks::AbstractVector{UnitRange{Cint}}
+        self.numel_linear = sum(cone.numel() for cone in self.cones[:self.n_linear])
+        self.max_linear = max(cone.numel() for cone in self.cones[:self.n_linear])
+        self.numel_soc = sum(cone.numel() for cone in self.cones[self.n_linear:self.n_linear + self.n_soc])
 
-    # the flag for symmetric cone check
-    _is_symmetric::Bool
-    n_linear::Cint
-    n_nn::Cint
-    n_soc::Cint
-    n_exp::Cint
-    n_pow::Cint
-    n_psd::Cint
+        self.w = cp.empty(self.numel_linear + self.numel_soc, dtype=cpucones.cones[0].dtype)
+        self.λ = cp.empty(self.numel_linear + self.numel_soc, dtype=cpucones.cones[0].dtype)
+        self.η = cp.empty(self.n_soc, dtype=cpucones.cones[0].dtype)
 
-    idx_eq::Vector{Cint}
-    idx_inq::Vector{Cint}
+        self.αp = cp.array([cone.α for cone in self.cones[self.n_linear + self.n_soc + self.n_exp:self.n_linear + self.n_soc + self.n_exp + self.n_pow]], dtype=cpucones.cones[0].dtype)
+        self.H_dual = cp.empty((self.n_exp + self.n_pow, 3, 3), dtype=cpucones.cones[0].dtype)
+        self.Hs = cp.empty((self.n_exp + self.n_pow, 3, 3), dtype=cpucones.cones[0].dtype)
+        self.grad = cp.empty((self.n_exp + self.n_pow, 3), dtype=cpucones.cones[0].dtype)
 
-    #data
-    w::AbstractVector{T}
-    λ::AbstractVector{T}
-    η::AbstractVector{T}
+        self.psd_dim = self.cones[self.n_linear + self.n_soc + self.n_exp + self.n_pow].n if self.n_psd > 0 else 0
+        for i in range(1, self.n_psd):
+            if self.psd_dim != self.cones[self.n_linear + self.n_soc + self.n_exp + self.n_pow + i].n:
+                raise ValueError("Not all positive definite cones have the same dimensionality!")
 
-    #nonsymmetric cone
-    αp::AbstractVector{T}           #power parameters of power cones
-    H_dual::AbstractArray{T}        #Hessian of the dual barrier at z 
-    Hs::AbstractArray{T}            #scaling matrix
-    grad::AbstractArray{T}         #gradient of the dual barrier at z 
+        self.chol1 = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.chol2 = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.SVD = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
 
-    #PSD cone
-    psd_dim::Cint                  #We only support PSD cones with the same small dimension
-    chol1::AbstractArray{T,3}
-    chol2::AbstractArray{T,3}
-    SVD::AbstractArray{T,3}
-    λpsd::AbstractMatrix{T}
-    Λisqrt::AbstractMatrix{T}
-    R::AbstractArray{T,3}
-    Rinv::AbstractArray{T,3}
-    Hspsd::AbstractArray{T,3}
+        self.λpsd = cp.zeros((self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.Λisqrt = cp.zeros((self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.R = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.Rinv = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.Hspsd = cp.zeros((self.psd_dim * (self.psd_dim + 1) // 2, self.psd_dim * (self.psd_dim + 1) // 2, self.n_psd), dtype=cpucones.cones[0].dtype)
 
-    #workspace for various internal uses
-    workmat1::AbstractArray{T,3}
-    workmat2::AbstractArray{T,3}
-    workmat3::AbstractArray{T,3}
-    workvec::AbstractVector{T}
+        self.workmat1 = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.workmat2 = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.workmat3 = cp.zeros((self.psd_dim, self.psd_dim, self.n_psd), dtype=cpucones.cones[0].dtype)
+        self.workvec = cp.zeros(self.psd_dim * (self.psd_dim + 1) // 2 * self.n_psd, dtype=cpucones.cones[0].dtype)
 
-    #step_size
-    α::AbstractVector{T}
+        self.α = cp.empty(sum(cone.numel() for cone in self.cones), dtype=cpucones.cones[0].dtype)
 
-    function CompositeConeGPU{T}(cpucones::CompositeCone{T}) where {T}
+    def __getitem__(self, i):
+        return self.cones[i]
 
-        #Information from the CompositeCone on CPU 
-        cones  = cpucones.cones
-        type_counts = cpucones.type_counts
-        _is_symmetric = cpucones._is_symmetric
+    def __len__(self):
+        return len(self.cones)
 
-        n_zero = haskey(type_counts,ZeroCone) ? type_counts[ZeroCone] : 0
-        n_nn = haskey(type_counts,NonnegativeCone) ? type_counts[NonnegativeCone] : 0
-        n_linear = n_zero + n_nn
-        n_soc = haskey(type_counts,SecondOrderCone) ? type_counts[SecondOrderCone] : 0
-        n_exp = haskey(type_counts,ExponentialCone) ? type_counts[ExponentialCone] : 0
-        n_pow = haskey(type_counts,PowerCone) ? type_counts[PowerCone] : 0
-        n_psd = haskey(type_counts,PSDTriangleCone) ? type_counts[PSDTriangleCone] : 0
+    def __iter__(self):
+        return iter(self.cones)
 
-        #idx set for eq and ineq constraints
-        idx_eq = Vector{Cint}([])
-        idx_inq = Vector{Cint}([])
-        for i in 1:n_linear
-            typeof(cones[i]) === ZeroCone{T} ? push!(idx_eq,i) : push!(idx_inq,i) 
-        end
-
-        #count up elements and degree
-        numel  = sum(cone -> Clarabel.numel(cone), cones; init = 0)
-        degree = sum(cone -> Clarabel.degree(cone), cones; init = 0)
-
-        @views numel_linear  = sum(cone -> Clarabel.numel(cone), cones[1:n_linear]; init = 0)
-        @views max_linear = maximum(cone -> Clarabel.numel(cone), cones[1:n_linear]; init = 0)
-        @views numel_soc  = sum(cone -> Clarabel.numel(cone), cones[n_linear+1:n_linear+n_soc]; init = 0)
-
-        w = CuVector{T}(undef,numel_linear+numel_soc)
-        λ = CuVector{T}(undef,numel_linear+numel_soc)
-        η = CuVector{T}(undef,n_soc)
-
-        #Initialize space for nonsymmetric cones
-        αp = Vector{T}(undef,n_pow)
-        pow_ind = n_linear + n_soc + n_exp
-        #store the power parameter of each power cone
-        for i in 1:n_pow
-            αp[i] = cones[i+pow_ind].α
-        end
-
-        αp = CuVector(αp)
-        H_dual = CuArray{T}(undef,n_exp+n_pow,3,3)
-        Hs = CuArray{T}(undef,n_exp+n_pow,3,3)
-        grad = CuArray{T}(undef,n_exp+n_pow,3)
-
-        #PSD cone
-        #We require all psd cones have the same dimensionality
-        psd_ind = pow_ind + n_pow
-        psd_dim = haskey(type_counts,PSDTriangleCone) ? cones[psd_ind+1].n : 0
-        for i in 1:n_psd
-            if(psd_dim != cones[psd_ind+i].n)
-                throw(DimensionMismatch("Not all positive definite cones have the same dimensionality!"))
-            end
-        end
-
-        chol1 = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-        chol2 = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-        SVD   = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-
-        λpsd   = CUDA.zeros(T,psd_dim,n_psd)
-        Λisqrt = CUDA.zeros(T,psd_dim,n_psd)
-        R      = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-        Rinv   = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-        Hspsd  = CUDA.zeros(T,triangular_number(psd_dim),triangular_number(psd_dim),n_psd)
-
-        workmat1 = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-        workmat2 = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-        workmat3 = CUDA.zeros(T,psd_dim,psd_dim,n_psd)
-        workvec  = CUDA.zeros(T,triangular_number(psd_dim)*n_psd)
-
-        α = CuVector{T}(undef,sum(cone -> Clarabel.numel(cone), cones; init = 0)) #workspace for step size calculation and neighborhood check
-
-        return new(cones,type_counts,numel,degree,CuVector(cpucones.rng_cones),CuVector(cpucones.rng_blocks),_is_symmetric,
-                n_linear, n_nn, n_soc, n_exp, n_pow, n_psd,
-                idx_eq,idx_inq,
-                w,λ,η,
-                αp,H_dual,Hs,grad,
-                psd_dim,chol1,chol2,SVD,λpsd,Λisqrt,R,Rinv,Hspsd,workmat1,workmat2,workmat3,workvec,
-                α)
-    end
-end
-
-CompositeConeGPU(args...) = CompositeConeGPU{DefaultFloat}(args...)
-
-
-# partial implementation of AbstractArray behaviours
-function Base.getindex(S::CompositeConeGPU{T}, i::Int) where {T}
-    @boundscheck checkbounds(S.cones,i)
-    @inbounds S.cones[i]
-end
-
-Base.getindex(S::CompositeConeGPU{T}, b::BitVector) where {T} = S.cones[b]
-Base.iterate(S::CompositeConeGPU{T}) where{T} = iterate(S.cones)
-Base.iterate(S::CompositeConeGPU{T}, state) where{T} = iterate(S.cones, state)
-Base.length(S::CompositeConeGPU{T}) where{T} = length(S.cones)
-Base.eachindex(S::CompositeConeGPU{T}) where{T} = eachindex(S.cones)
-Base.IndexStyle(S::CompositeConeGPU{T}) where{T} = IndexStyle(S.cones)
-
-function get_type_count(cones::CompositeConeGPU{T}, type::Type) where {T}
-    if haskey(cones.type_counts,type)
-        return cones.type_counts[type]
-    else
-        return Cint(0)
-    end
-end
+    def get_type_count(self, type):
+        return self.type_counts.get(type, 0)

--- a/src/gpucones/coneops_compositecone_gpu.jl
+++ b/src/gpucones/coneops_compositecone_gpu.jl
@@ -1,51 +1,61 @@
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
 
-degree(cones::CompositeConeGPU{T}) where {T} = cones.degree
-numel(cones::CompositeConeGPU{T}) where {T}  = cones.numel
+def degree(cones):
+    return cones.degree
 
-# # -----------------------------------------------------
-# # dispatch operators for multiple cones
-# # -----------------------------------------------------
+def numel(cones):
+    return cones.numel
 
-function is_symmetric(cones::CompositeConeGPU{T}) where {T}
-    #true if all pieces are symmetric.  
-    #determined during obj construction
+def is_symmetric(cones):
     return cones._is_symmetric
-end
 
-function allows_primal_dual_scaling(cones::CompositeConeGPU{T}) where {T}
-    all(allows_primal_dual_scaling, cones)
-end
+def allows_primal_dual_scaling(cones):
+    return all(allows_primal_dual_scaling(cone) for cone in cones)
 
+@njit
+def margins_nonnegative(z, α, rng_cones, idx_inq, αmin):
+    val = 0
+    for i in idx_inq:
+        rng = rng_cones[i]
+        α[rng] = np.minimum(α[rng], z[rng])
+        αmin = np.minimum(αmin, np.min(α[rng]))
+        val += np.sum(np.maximum(0, z[rng]))
+    return αmin, val
 
-# function rectify_equilibration!(
-#     cones::CompositeCone{T},
-#      δ::AbstractVector{T},
-#      e::AbstractVector{T}
-# ) where{T}
+@njit
+def margins_soc(z, α, rng_cones, n_shift, n_soc, αmin):
+    val = 0
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        size_i = len(rng)
+        zi = z[rng]
+        α[shift_i] = np.minimum(α[shift_i], zi[0] - np.sqrt(np.sum(zi[1:]**2)))
+        αmin = np.minimum(αmin, α[shift_i])
+        val += np.sum(np.maximum(0, zi))
+    return αmin, val
 
-#     any_changed = false
+@njit
+def margins_psd(Z, z, rng_cones, n_shift, n_psd, αmin):
+    val = 0
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        zi = z[rng]
+        Z[i] = np.reshape(zi, (int(np.sqrt(len(zi))), -1))
+        e = np.linalg.eigvalsh(Z[i])
+        αmin = np.minimum(αmin, np.min(e))
+        val += np.sum(np.maximum(0, e))
+    return αmin, val
 
-#     #we will update e <- δ .* e using return values
-#     #from this function.  default is to do nothing at all
-#     δ .= 1
-
-#     for (cone,δi,ei) in zip(cones,δ.views,e.views)
-#         @conedispatch any_changed |= rectify_equilibration!(cone,δi,ei)
-#     end
-
-#     return any_changed
-# end
-
-function margins(
-    cones::CompositeConeGPU{T},
-    z::AbstractVector{T},
-    pd::PrimalOrDualCone,
-) where {T}
-    αmin = typemax(T)
-    β = zero(T)
+def margins(cones, z, pd):
+    αmin = np.finfo(z.dtype).max
+    β = 0
 
     n_linear = cones.n_linear
-    n_nn  = cones.n_nn
+    n_nn = cones.n_nn
     n_soc = cones.n_soc
     n_psd = cones.n_psd
     rng_cones = cones.rng_cones
@@ -53,35 +63,52 @@ function margins(
     Z = cones.workmat1
 
     α = cones.α
-    @. α = αmin
-    
-    if n_nn > 0
-        (αmin,val) = margins_nonnegative(z, α, rng_cones, idx_inq, αmin)
-        β += val
-    end
+    α.fill(αmin)
 
-    if n_soc > 0
+    if n_nn > 0:
+        αmin, val = margins_nonnegative(z, α, rng_cones, idx_inq, αmin)
+        β += val
+
+    if n_soc > 0:
         n_shift = n_linear
-        (αmin,val) = margins_soc(z, α, rng_cones, n_shift, n_soc, αmin)
+        αmin, val = margins_soc(z, α, rng_cones, n_shift, n_soc, αmin)
         β += val
-    end
 
-    if n_psd > 0
+    if n_psd > 0:
         n_shift = n_linear + n_soc
-        (αmin,val) = margins_psd(Z, z, rng_cones, n_shift, n_psd, αmin)
+        αmin, val = margins_psd(Z, z, rng_cones, n_shift, n_psd, αmin)
         β += val
-    end
 
-    return (αmin,β)
-end
+    return αmin, β
 
-function scaled_unit_shift!(
-    cones::CompositeConeGPU{T},
-    z::AbstractVector{T},
-    α::T,
-    pd::PrimalOrDualCone
-) where {T}
+@njit
+def scaled_unit_shift_zero(z, rng_cones, idx_eq, pd):
+    for i in idx_eq:
+        rng = rng_cones[i]
+        z[rng] = 0
 
+@njit
+def scaled_unit_shift_nonnegative(z, rng_cones, idx_inq, α):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        z[rng] = α
+
+@njit
+def scaled_unit_shift_soc(z, rng_cones, α, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        z[rng[0]] += α
+
+@njit
+def scaled_unit_shift_psd(z, α, rng_cones, psd_dim, n_shift, n_psd):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        for k in range(psd_dim):
+            z[rng[k * (k + 1) // 2 + k]] += α
+
+def scaled_unit_shift(cones, z, α, pd):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_psd = cones.n_psd
@@ -90,31 +117,75 @@ function scaled_unit_shift!(
     idx_eq = cones.idx_eq
     idx_inq = cones.idx_inq
 
-    scaled_unit_shift_zero!(z, rng_cones, idx_eq, pd)
+    scaled_unit_shift_zero(z, rng_cones, idx_eq, pd)
+    scaled_unit_shift_nonnegative(z, rng_cones, idx_inq, α)
 
-    scaled_unit_shift_nonnegative!(z, rng_cones, idx_inq, α)
-
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
-        scaled_unit_shift_soc!(z, rng_cones, α, n_shift, n_soc)
-    end
+        scaled_unit_shift_soc(z, rng_cones, α, n_shift, n_soc)
 
-    if n_psd > 0
+    if n_psd > 0:
         n_shift = n_linear + n_soc
-        scaled_unit_shift_psd!(z, α, rng_cones, psd_dim, n_shift, n_psd)
-    end
+        scaled_unit_shift_psd(z, α, rng_cones, psd_dim, n_shift, n_psd)
 
-    return nothing
+    return
 
-end
+@njit
+def unit_initialization_zero(z, s, rng_cones, idx_eq):
+    for i in idx_eq:
+        rng = rng_cones[i]
+        z[rng] = 0
+        s[rng] = 0
 
-# unit initialization for asymmetric solves
-function unit_initialization!(
-    cones::CompositeConeGPU{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T}
-) where {T}
+@njit
+def unit_initialization_nonnegative(z, s, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        z[rng] = 1
+        s[rng] = 1
 
+@njit
+def unit_initialization_soc(z, s, rng_cones, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        z[rng[0]] = 1
+        z[rng[1:]] = 0
+        s[rng[0]] = 1
+        s[rng[1:]] = 0
+
+@njit
+def unit_initialization_exp(z, s, rng_cones, n_shift, n_exp):
+    for i in range(n_exp):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        s[rng[0]] = -1.051383945322714
+        s[rng[1]] = 0.556409619469370
+        s[rng[2]] = 1.258967884768947
+        z[rng] = s[rng]
+
+@njit
+def unit_initialization_pow(z, s, αp, rng_cones, n_shift, n_pow):
+    for i in range(n_pow):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        s[rng[0]] = np.sqrt(1 + αp[i])
+        s[rng[1]] = np.sqrt(1 + (1 - αp[i]))
+        s[rng[2]] = 0
+        z[rng] = s[rng]
+
+@njit
+def unit_initialization_psd(z, s, rng_cones, psd_dim, n_shift, n_psd):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        z[rng] = 0
+        s[rng] = 0
+        for k in range(psd_dim):
+            z[rng[k * (k + 1) // 2 + k]] = 1
+            s[rng[k * (k + 1) // 2 + k]] = 1
+
+def unit_initialization(cones, z, s):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_exp = cones.n_exp
@@ -127,38 +198,52 @@ function unit_initialization!(
     idx_eq = cones.idx_eq
     idx_inq = cones.idx_inq
 
-    unit_initialization_zero!(z, s, rng_cones, idx_eq)
+    unit_initialization_zero(z, s, rng_cones, idx_eq)
+    unit_initialization_nonnegative(z, s, rng_cones, idx_inq)
 
-    unit_initialization_nonnegative!(z, s, rng_cones, idx_inq)
-    
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
-        unit_initialization_soc!(z, s, rng_cones, n_shift, n_soc)
-    end
+        unit_initialization_soc(z, s, rng_cones, n_shift, n_soc)
 
-    if n_exp > 0
-        n_shift = n_linear+n_soc
-        unit_initialization_exp!(z, s, rng_cones, n_shift, n_exp)
-    end
+    if n_exp > 0:
+        n_shift = n_linear + n_soc
+        unit_initialization_exp(z, s, rng_cones, n_shift, n_exp)
 
-    if n_pow > 0
-        n_shift = n_linear+n_soc+n_exp
-        unit_initialization_pow!(z, s, αp, rng_cones, n_shift, n_pow)
-    end
+    if n_pow > 0:
+        n_shift = n_linear + n_soc + n_exp
+        unit_initialization_pow(z, s, αp, rng_cones, n_shift, n_pow)
 
-    if n_psd > 0
-        n_shift = n_linear+n_soc+n_exp+n_pow
-        unit_initialization_psd_gpu!(z,s,rng_cones,psd_dim,n_shift,n_psd)
-    end
+    if n_psd > 0:
+        n_shift = n_linear + n_soc + n_exp + n_pow
+        unit_initialization_psd(z, s, rng_cones, psd_dim, n_shift, n_psd)
 
-    return nothing
+    return
 
-end
+@njit
+def set_identity_scaling_nonnegative(w, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        w[rng] = 1
 
-function set_identity_scaling!(
-    cones::CompositeConeGPU{T}
-) where {T}
+@njit
+def set_identity_scaling_soc(w, η, rng_cones, n_linear, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_linear
+        rng = rng_cones[shift_i]
+        w[rng[0]] = 1
+        w[rng[1:]] = 0
+        η[i] = 1
 
+@njit
+def set_identity_scaling_psd(R, Rinv, Hspsd, psd_dim, n_psd):
+    for i in range(n_psd):
+        for k in range(psd_dim):
+            R[k, k, i] = 1
+            Rinv[k, k, i] = 1
+        for k in range(psd_dim * (psd_dim + 1) // 2):
+            Hspsd[k, k, i] = 1
+
+def set_identity_scaling(cones):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_psd = cones.n_psd
@@ -170,28 +255,95 @@ function set_identity_scaling!(
     Rinv = cones.Rinv
     Hspsd = cones.Hspsd
     psd_dim = cones.psd_dim
-    
-    set_identity_scaling_nonnegative!(w, rng_cones, idx_inq)
 
-    if n_soc > 0
-        set_identity_scaling_soc!(w, η, rng_cones, n_linear, n_soc)
-    end
+    set_identity_scaling_nonnegative(w, rng_cones, idx_inq)
 
-    if n_psd > 0
-        set_identity_scaling_psd!(R, Rinv, Hspsd, psd_dim, n_psd)
-    end
+    if n_soc > 0:
+        set_identity_scaling_soc(w, η, rng_cones, n_linear, n_soc)
 
-    return nothing
-end
+    if n_psd > 0:
+        set_identity_scaling_psd(R, Rinv, Hspsd, psd_dim, n_psd)
 
-function update_scaling!(
-    cones::CompositeConeGPU{T},
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-	μ::T,
-    scaling_strategy::ScalingStrategy
-) where {T}
+    return
 
+@njit
+def update_scaling_nonnegative(s, z, w, λ, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        w[rng] = s[rng] / np.sqrt(s[rng] * z[rng])
+        λ[rng] = np.sqrt(s[rng] * z[rng])
+
+@njit
+def update_scaling_soc(s, z, w, λ, η, rng_cones, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        zi = z[rng]
+        si = s[rng]
+        wi = w[rng]
+        λi = λ[rng]
+
+        zscale = np.sqrt(zi[0]**2 - np.sum(zi[1:]**2))
+        sscale = np.sqrt(si[0]**2 - np.sum(si[1:]**2))
+
+        η[i] = np.sqrt(sscale / zscale)
+
+        wi[:] = si / sscale
+        wi[0] += zi[0] / zscale
+        wi[1:] -= zi[1:] / zscale
+
+        wscale = np.sqrt(wi[0]**2 - np.sum(wi[1:]**2))
+        wi /= wscale
+
+        w1sq = np.sum(wi[1:]**2)
+        wi[0] = np.sqrt(1 + w1sq)
+
+        γi = 0.5 * wscale
+        λi[0] = γi
+
+        coef = 1 / (si[0] / sscale + zi[0] / zscale + 2 * γi)
+        c1 = (γi + zi[0] / zscale) / sscale
+        c2 = (γi + si[0] / sscale) / zscale
+        λi[1:] = coef * (c1 * si[1:] + c2 * zi[1:])
+        λi *= np.sqrt(sscale * zscale)
+
+@njit
+def update_scaling_psd(L1, L2, z, s, workmat1, λpsd, Λisqrt, R, Rinv, Hspsd, rng_cones, n_shift, n_psd):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        zi = z[rng]
+        si = s[rng]
+        L2[i] = np.reshape(zi, (int(np.sqrt(len(zi))), -1))
+        L1[i] = np.reshape(si, (int(np.sqrt(len(si))), -1))
+
+        _, infoz = np.linalg.cholesky(L2[i])
+        _, infos = np.linalg.cholesky(L1[i])
+
+        if not (np.all(infoz == 0) and np.all(infos == 0)):
+            return False
+
+        tmp = workmat1
+        tmp[i] = np.dot(L2[i].T, L1[i])
+        U, S, V = np.linalg.svd(tmp[i])
+
+        λpsd[:, i] = S
+        Λisqrt[:, i] = 1 / np.sqrt(λpsd[:, i])
+
+        R[i] = np.dot(L1[i], V)
+        R[i] = np.dot(R[i], np.diag(Λisqrt[:, i]))
+
+        Rinv[i] = np.dot(U.T, L2[i].T)
+        Rinv[i] = np.dot(np.diag(Λisqrt[:, i]), Rinv[i])
+
+        RRt = workmat1
+        RRt[i] = np.dot(R[i], R[i].T)
+
+        Hspsd[i] = np.kron(RRt[i], RRt[i])
+
+    return True
+
+def update_scaling(cones, s, z, μ, scaling_strategy):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_exp = cones.n_exp
@@ -206,38 +358,86 @@ function update_scaling!(
     w = cones.w
     λ = cones.λ
     η = cones.η
-    
-    update_scaling_nonnegative!(s, z, w, λ, rng_cones, idx_inq)
 
-    if n_soc > 0
+    update_scaling_nonnegative(s, z, w, λ, rng_cones, idx_inq)
+
+    if n_soc > 0:
         n_shift = n_linear
-        update_scaling_soc!(s, z, w, λ, η, rng_cones, n_shift, n_soc)
-    end
+        update_scaling_soc(s, z, w, λ, η, rng_cones, n_shift, n_soc)
 
-    if n_exp > 0
-        n_shift = n_linear+n_soc
-        update_scaling_exp!(s, z, grad, Hs, H_dual, rng_cones, μ, scaling_strategy, n_shift, n_exp)
-    end
+    if n_exp > 0:
+        n_shift = n_linear + n_soc
+        update_scaling_exp(s, z, grad, Hs, H_dual, rng_cones, μ, scaling_strategy, n_shift, n_exp)
 
-    if n_pow > 0
-        n_shift = n_linear+n_soc+n_exp
-        update_scaling_pow!(s, z, grad, Hs, H_dual, αp, rng_cones, μ, scaling_strategy, n_shift, n_exp, n_pow)
-    end
+    if n_pow > 0:
+        n_shift = n_linear + n_soc + n_exp
+        update_scaling_pow(s, z, grad, Hs, H_dual, αp, rng_cones, μ, scaling_strategy, n_shift, n_exp, n_pow)
 
-    if n_psd > 0
-        n_shift = n_linear+n_soc+n_exp+n_pow
-        update_scaling_psd!(cones.chol1, cones.chol2, z, s, cones.workmat1, cones.λpsd, cones.Λisqrt, cones.R, cones.Rinv, cones.Hspsd, rng_cones, n_shift, n_psd)
-    end
+    if n_psd > 0:
+        n_shift = n_linear + n_soc + n_exp + n_pow
+        update_scaling_psd(cones.chol1, cones.chol2, z, s, cones.workmat1, cones.λpsd, cones.Λisqrt, cones.R, cones.Rinv, cones.Hspsd, rng_cones, n_shift, n_psd)
 
-    return is_scaling_success = true
-end
+    return True
 
-# Update Hs block for each cone.
-function get_Hs!(
-    cones::CompositeConeGPU{T},
-    Hsblocks::AbstractVector{T}
-) where {T}
+@njit
+def get_Hs_zero(Hsblocks, rng_blocks, idx_eq):
+    for i in idx_eq:
+        rng = rng_blocks[i]
+        Hsblocks[rng] = 0
 
+@njit
+def get_Hs_nonnegative(Hsblocks, w, rng_cones, rng_blocks, idx_inq):
+    for i in idx_inq:
+        rng_cone = rng_cones[i]
+        rng_block = rng_blocks[i]
+        Hsblocks[rng_block] = 2 * np.outer(w[rng_cone], w[rng_cone])
+        Hsblocks[rng_block[0]] -= 1
+        for j in range(1, len(rng_cone)):
+            Hsblocks[rng_block[j * len(rng_cone) + j]] += 1
+
+@njit
+def get_Hs_soc(Hsblocks, w, η, rng_cones, rng_blocks, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng_cone = rng_cones[shift_i]
+        rng_block = rng_blocks[shift_i]
+        size_i = len(rng_cone)
+        wi = w[rng_cone]
+        Hsblocki = Hsblocks[rng_block]
+
+        hidx = 0
+        for col in range(size_i):
+            wcol = wi[col]
+            for row in range(size_i):
+                Hsblocki[hidx] = 2 * wi[row] * wcol
+                hidx += 1
+        Hsblocki[0] -= 1
+        for ind in range(1, size_i):
+            Hsblocki[(ind - 1) * size_i + ind] += 1
+        Hsblocki *= η[i]**2
+
+@njit
+def get_Hs_exp(Hsblocks, Hs, rng_blocks, n_shift, n_exp):
+    for i in range(n_exp):
+        shift_i = i + n_shift
+        rng_block = rng_blocks[shift_i]
+        Hsblocks[rng_block] = Hs[i].flatten()
+
+@njit
+def get_Hs_pow(Hsblocks, Hs, rng_blocks, n_shift, n_exp, n_pow):
+    for i in range(n_pow):
+        shift_i = i + n_shift
+        rng_block = rng_blocks[shift_i]
+        Hsblocks[rng_block] = Hs[n_exp + i].flatten()
+
+@njit
+def get_Hs_psd(Hsblocks, Hspsd, rng_blocks, n_shift, n_psd):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng_block = rng_blocks[shift_i]
+        Hsblocks[rng_block] = Hspsd[i].flatten()
+
+def get_Hs(cones, Hsblocks):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_exp = cones.n_exp
@@ -252,44 +452,77 @@ function get_Hs!(
     w = cones.w
     η = cones.η
 
-    get_Hs_zero!(Hsblocks, rng_blocks, idx_eq)
+    get_Hs_zero(Hsblocks, rng_blocks, idx_eq)
+    get_Hs_nonnegative(Hsblocks, w, rng_cones, rng_blocks, idx_inq)
 
-    get_Hs_nonnegative!(Hsblocks, w, rng_cones, rng_blocks, idx_inq)
-
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
-        get_Hs_soc!(Hsblocks, w, η, rng_cones, rng_blocks, n_shift, n_soc)
-    end
+        get_Hs_soc(Hsblocks, w, η, rng_cones, rng_blocks, n_shift, n_soc)
 
-    if n_exp > 0
-        n_shift = n_linear+n_soc
-        get_Hs_exp!(Hsblocks, Hs, rng_blocks, n_shift, n_exp)
-    end
+    if n_exp > 0:
+        n_shift = n_linear + n_soc
+        get_Hs_exp(Hsblocks, Hs, rng_blocks, n_shift, n_exp)
 
-    if n_pow > 0
-        n_shift = n_linear+n_soc+n_exp
-        get_Hs_pow!(Hsblocks, Hs, rng_blocks, n_shift, n_exp, n_pow)
-    end
+    if n_pow > 0:
+        n_shift = n_linear + n_soc + n_exp
+        get_Hs_pow(Hsblocks, Hs, rng_blocks, n_shift, n_exp, n_pow)
 
-    if n_psd > 0
-        n_shift = n_linear+n_soc+n_exp+n_pow
-        get_Hs_psd!(Hsblocks, Hspsd, rng_blocks, n_shift, n_psd)
-    end
+    if n_psd > 0:
+        n_shift = n_linear + n_soc + n_exp + n_pow
+        get_Hs_psd(Hsblocks, Hspsd, rng_blocks, n_shift, n_psd)
 
-    return nothing
-end
+    return
 
-# compute the generalized product :
-# WᵀWx for symmetric cones 
-# μH(s)x for symmetric cones
+@njit
+def mul_Hs_zero(y, rng_cones, idx_eq):
+    for i in idx_eq:
+        rng = rng_cones[i]
+        y[rng] = 0
 
-function mul_Hs!(
-    cones::CompositeConeGPU{T},
-    y::AbstractVector{T},
-    x::AbstractVector{T},
-    work::AbstractVector{T}
-) where {T}
+@njit
+def mul_Hs_nonnegative(y, x, w, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        y[rng] = 2 * w[rng] * np.dot(w[rng], x[rng]) - x[rng]
 
+@njit
+def mul_Hs_soc(y, x, w, η, rng_cones, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        size_i = len(rng)
+        xi = x[rng]
+        wi = w[rng]
+        yi = y[rng]
+
+        c = 2 * np.dot(wi, xi)
+        yi[0] = -xi[0] + c * wi[0]
+        yi[1:] = xi[1:] + c * wi[1:]
+        yi *= η[i]**2
+
+@njit
+def mul_Hs_nonsymmetric(y, Hs, x, rng_cones, n_shift, n_nonsymmetric):
+    for i in range(n_nonsymmetric):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        y[rng] = np.dot(Hs[i], x[rng])
+
+@njit
+def mul_Hs_psd(y, x, Hspsd, rng_cones, n_shift, n_psd, psd_dim):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        xi = x[rng]
+        yi = y[rng]
+        Hspsdi = Hspsd[i]
+
+        n_tri_dim = psd_dim * (psd_dim + 1) // 2
+        X = xi.reshape((n_tri_dim, n_psd))
+        Y = yi.reshape((n_tri_dim, n_psd))
+
+        Y[:] = np.dot(Hspsdi, X)
+
+def mul_Hs(cones, y, x, work):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_exp = cones.n_exp
@@ -304,36 +537,68 @@ function mul_Hs!(
     w = cones.w
     η = cones.η
 
-    mul_Hs_zero!(y, rng_cones, idx_eq)
-    
-    mul_Hs_nonnegative!(y, x, w, rng_cones, idx_inq)
+    mul_Hs_zero(y, rng_cones, idx_eq)
+    mul_Hs_nonnegative(y, x, w, rng_cones, idx_inq)
 
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
-        mul_Hs_soc!(y, x, w, η, rng_cones, n_shift, n_soc)
-    end
+        mul_Hs_soc(y, x, w, η, rng_cones, n_shift, n_soc)
 
     n_nonsymmetric = n_exp + n_pow
-    if n_nonsymmetric > 0
-        n_shift = n_linear+n_soc
-        mul_Hs_nonsymmetric!(y, Hs, x, rng_cones, n_shift, n_nonsymmetric)
-    end
+    if n_nonsymmetric > 0:
+        n_shift = n_linear + n_soc
+        mul_Hs_nonsymmetric(y, Hs, x, rng_cones, n_shift, n_nonsymmetric)
 
-    if n_psd > 0
-        n_shift = n_linear+n_soc+n_exp+n_pow
-        mul_Hs_psd!(y, x, Hspsd, rng_cones, n_shift, n_psd, psd_dim)
-    end
+    if n_psd > 0:
+        n_shift = n_linear + n_soc + n_exp + n_pow
+        mul_Hs_psd(y, x, Hspsd, rng_cones, n_shift, n_psd, psd_dim)
 
-    return nothing
-end
+    return
 
-# x = λ ∘ λ for symmetric cone and x = s for asymmetric cones
-function affine_ds!(
-    cones::CompositeConeGPU{T},
-    ds::AbstractVector{T},
-    s::AbstractVector{T}
-) where {T}
+@njit
+def affine_ds_zero(ds, rng_cones, idx_eq):
+    for i in idx_eq:
+        rng = rng_cones[i]
+        ds[rng] = 0
 
+@njit
+def affine_ds_nonnegative(ds, λ, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        ds[rng] = λ[rng]**2
+
+@njit
+def affine_ds_soc(ds, λ, rng_cones, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        size_i = len(rng)
+        λi = λ[rng]
+        dsi = ds[rng]
+
+        dsi[0] = np.sum(λi**2)
+        λi0 = λi[0]
+        dsi[1:] = 2 * λi0 * λi[1:]
+
+@njit
+def affine_ds_nonsymmetric(ds, s, rng_cones, n_shift, n_nonsymmetric):
+    for i in range(n_nonsymmetric):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        ds[rng] = s[rng]
+
+@njit
+def affine_ds_psd(ds, λpsd, rng_cones, psd_dim, n_shift, n_psd):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        dsi = ds[rng]
+        λpsdi = λpsd[:, i]
+
+        for k in range(psd_dim):
+            dsi[k * (k + 1) // 2 + k] = λpsdi[k]**2
+
+def affine_ds(cones, ds, s):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_exp = cones.n_exp
@@ -346,39 +611,127 @@ function affine_ds!(
     psd_dim = cones.psd_dim
     λpsd = cones.λpsd
 
-    affine_ds_zero!(ds, rng_cones, idx_eq)
+    affine_ds_zero(ds, rng_cones, idx_eq)
+    affine_ds_nonnegative(ds, λ, rng_cones, idx_inq)
 
-    affine_ds_nonnegative!(ds, λ, rng_cones, idx_inq)
-
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
-        affine_ds_soc!(ds, λ, rng_cones, n_shift, n_soc)
-    end
+        affine_ds_soc(ds, λ, rng_cones, n_shift, n_soc)
 
-    #update nonsymmetric cones
     n_nonsymmetric = n_exp + n_pow
-    if n_nonsymmetric > 0
+    if n_nonsymmetric > 0:
         n_shift = n_linear + n_soc
-        affine_ds_nonsymmetric!(ds, s, rng_cones, n_shift, n_nonsymmetric)
-    end
+        affine_ds_nonsymmetric(ds, s, rng_cones, n_shift, n_nonsymmetric)
 
-    if n_psd > 0
+    if n_psd > 0:
         n_shift = n_linear + n_soc + n_exp + n_pow
-        affine_ds_psd_gpu!(ds,λpsd,rng_cones,psd_dim,n_shift,n_psd)
-    end
+        affine_ds_psd(ds, λpsd, rng_cones, psd_dim, n_shift, n_psd)
 
-    return nothing
-end
+    return
 
-function combined_ds_shift!(
-    cones::CompositeConeGPU{T},
-    shift::AbstractVector{T},
-    step_z::AbstractVector{T},
-    step_s::AbstractVector{T},
-    z::AbstractVector{T},
-    σμ::T
-) where {T}
+@njit
+def combined_ds_shift_zero(shift, rng_cones, idx_eq):
+    for i in idx_eq:
+        rng = rng_cones[i]
+        shift[rng] = 0
 
+@njit
+def combined_ds_shift_nonnegative(shift, step_z, step_s, w, σμ, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        shift[rng] = w[rng] * (step_z[rng] + step_s[rng]) - σμ
+
+@njit
+def combined_ds_shift_soc(shift, step_z, step_s, w, η, rng_cones, n_shift, n_soc, σμ):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        size_i = len(rng)
+        step_zi = step_z[rng]
+        step_si = step_s[rng]
+        wi = w[rng]
+        shifti = shift[rng]
+
+        tmp = step_zi.copy()
+        ζ = np.dot(wi[1:], tmp[1:])
+        c = tmp[0] + ζ / (1 + wi[0])
+        step_zi[0] = η[i] * (wi[0] * tmp[0] + ζ)
+        step_zi[1:] = η[i] * (tmp[1:] + c * wi[1:])
+
+        tmp = step_si.copy()
+        ζ = np.dot(wi[1:], tmp[1:])
+        c = -tmp[0] + ζ / (1 + wi[0])
+        step_si[0] = (1 / η[i]) * (wi[0] * tmp[0] - ζ)
+        step_si[1:] = (1 / η[i]) * (tmp[1:] + c * wi[1:])
+
+        val = np.dot(step_si, step_zi)
+        shifti[0] = val - σμ
+        s0 = step_si[0]
+        z0 = step_zi[0]
+        shifti[1:] = s0 * step_zi[1:] + z0 * step_si[1:]
+
+@njit
+def combined_ds_shift_exp(shift, step_z, step_s, z, grad, H_dual, rng_cones, σμ, n_shift, n_exp):
+    for i in range(n_exp):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        step_zi = step_z[rng]
+        step_si = step_s[rng]
+        zi = z[rng]
+        gradi = grad[i]
+        Hi = H_dual[i]
+        shifti = shift[rng]
+
+        η = np.zeros(3)
+        higher_correction_exp(Hi, zi, η, step_si, step_zi)
+
+        shifti[:] = gradi * σμ - η
+
+@njit
+def combined_ds_shift_pow(shift, step_z, step_s, z, grad, H_dual, αp, rng_cones, σμ, n_shift, n_exp, n_pow):
+    for i in range(n_pow):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        step_zi = step_z[rng]
+        step_si = step_s[rng]
+        zi = z[rng]
+        gradi = grad[n_exp + i]
+        Hi = H_dual[n_exp + i]
+        shifti = shift[rng]
+
+        η = np.zeros(3)
+        higher_correction_pow(Hi, zi, η, step_si, step_zi, αp[i])
+
+        shifti[:] = gradi * σμ - η
+
+@njit
+def combined_ds_shift_psd(cones, shift, step_z, step_s, n_shift, n_psd, σμ):
+    tmp = shift.copy()
+    R = cones.R
+    Rinv = cones.Rinv
+    rng_cones = cones.rng_cones
+    workmat1 = cones.workmat1
+    workmat2 = cones.workmat2
+    workmat3 = cones.workmat3
+    psd_dim = cones.psd_dim
+
+    rng = np.concatenate([rng_cones[i] for i in range(n_shift + 1, n_shift + n_psd + 1)])
+
+    tmp[rng] = step_z[rng]
+    mul_Wx_psd(step_z, tmp, R, rng_cones, workmat1, workmat2, workmat3, n_shift, n_psd, False)
+
+    tmp[rng] = step_s[rng]
+    mul_WTx_psd(step_s, tmp, Rinv, rng_cones, workmat1, workmat2, workmat3, n_shift, n_psd, False)
+
+    svec_to_mat(workmat1, step_z, rng_cones, n_shift, n_psd)
+    svec_to_mat(workmat2, step_s, rng_cones, n_shift, n_psd)
+    workmat3 = np.dot(workmat1, workmat2)
+    workmat3 = (workmat3 + workmat3.T) / 2
+
+    mat_to_svec(shift, workmat3, rng_cones, n_shift, n_psd)
+    scaled_unit_shift_psd(shift, -σμ, rng_cones, psd_dim, n_shift, n_psd)
+
+def combined_ds_shift(cones, shift, step_z, step_s, z, σμ):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_exp = cones.n_exp
@@ -393,44 +746,90 @@ function combined_ds_shift!(
     w = cones.w
     η = cones.η
 
-    CUDA.synchronize()
-    
-    combined_ds_shift_zero!(shift, rng_cones, idx_eq)
-    
-    combined_ds_shift_nonnegative!(shift, step_z, step_s, w, σμ, rng_cones, idx_inq)
+    combined_ds_shift_zero(shift, rng_cones, idx_eq)
+    combined_ds_shift_nonnegative(shift, step_z, step_s, w, σμ, rng_cones, idx_inq)
 
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
-        combined_ds_shift_soc!(shift, step_z, step_s, w, η, rng_cones, n_shift, n_soc, σμ)
-    end
+        combined_ds_shift_soc(shift, step_z, step_s, w, η, rng_cones, n_shift, n_soc, σμ)
 
-    if n_exp > 0
-        n_shift = n_linear+n_soc
-        combined_ds_shift_exp!(shift, step_z, step_s, z, grad, H_dual, rng_cones, σμ, n_shift, n_exp)
-    end
+    if n_exp > 0:
+        n_shift = n_linear + n_soc
+        combined_ds_shift_exp(shift, step_z, step_s, z, grad, H_dual, rng_cones, σμ, n_shift, n_exp)
 
-    if n_pow > 0
-        n_shift = n_linear+n_soc+n_exp
-        combined_ds_shift_pow!(shift, step_z, step_s, z, grad, H_dual, αp, rng_cones, σμ, n_shift, n_exp, n_pow)
-    end
-    
-    if n_psd > 0 
-        n_shift = n_linear+n_soc+n_exp+n_pow
-        combined_ds_shift_psd!(cones,shift,step_z,step_s,n_shift,n_psd,σμ)
-    end
+    if n_pow > 0:
+        n_shift = n_linear + n_soc + n_exp
+        combined_ds_shift_pow(shift, step_z, step_s, z, grad, H_dual, αp, rng_cones, σμ, n_shift, n_exp, n_pow)
 
-    return nothing
+    if n_psd > 0:
+        n_shift = n_linear + n_soc + n_exp + n_pow
+        combined_ds_shift_psd(cones, shift, step_z, step_s, n_shift, n_psd, σμ)
 
-end
+    return
 
-function Δs_from_Δz_offset!(
-    cones::CompositeConeGPU{T},
-    out::AbstractVector{T},
-    ds::AbstractVector{T},
-    work::AbstractVector{T},
-    z::AbstractVector{T}
-) where {T}
+@njit
+def Δs_from_Δz_offset_zero(out, rng_cones, idx_eq):
+    for i in idx_eq:
+        rng = rng_cones[i]
+        out[rng] = 0
 
+@njit
+def Δs_from_Δz_offset_nonnegative(out, ds, z, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        out[rng] = ds[rng] - z[rng]
+
+@njit
+def Δs_from_Δz_offset_soc(out, ds, z, w, λ, η, rng_cones, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        size_i = len(rng)
+        dsi = ds[rng]
+        zi = z[rng]
+        wi = w[rng]
+        λi = λ[rng]
+        outi = out[rng]
+
+        reszi = np.sqrt(zi[0]**2 - np.sum(zi[1:]**2))
+        λ1ds1 = np.dot(λi[1:], dsi[1:])
+        w1ds1 = np.dot(wi[1:], dsi[1:])
+
+        outi[:] = -zi
+        outi[0] = zi[0]
+
+        c = λi[0] * dsi[0] - λ1ds1
+        outi *= c / reszi
+
+        outi[0] += η[i] * w1ds1
+        outi[1:] += η[i] * (dsi[1:] + w1ds1 / (1 + wi[0]) * wi[1:])
+
+        outi /= λi[0]
+
+@njit
+def Δs_from_Δz_offset_nonsymmetric(out, ds, rng_cones, n_shift, n_nonsymmetric):
+    for i in range(n_nonsymmetric):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        out[rng] = ds[rng]
+
+@njit
+def Δs_from_Δz_offset_psd(cones, out, ds, work, n_shift, n_psd):
+    R = cones.R
+    λpsd = cones.λpsd
+    rng_cones = cones.rng_cones
+    workmat1 = cones.workmat1
+    workmat2 = cones.workmat2
+    workmat3 = cones.workmat3
+    psd_dim = cones.psd_dim
+
+    svec_to_mat(workmat2, ds, rng_cones, n_shift, n_psd)
+    op_λ(workmat1, workmat2, λpsd, psd_dim, n_psd)
+    mat_to_svec(work, workmat1, rng_cones, n_shift, n_psd)
+
+    mul_WTx_psd(out, work, R, rng_cones, workmat1, workmat2, workmat3, n_shift, n_psd, False)
+
+def Δs_from_Δz_offset(cones, out, ds, work, z):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
     n_exp = cones.n_exp
@@ -443,155 +842,161 @@ function Δs_from_Δz_offset!(
     λ = cones.λ
     η = cones.η
 
-    Δs_from_Δz_offset_zero!(out, rng_cones, idx_eq)
-    
-    Δs_from_Δz_offset_nonnegative!(out, ds, z, rng_cones, idx_inq)
+    Δs_from_Δz_offset_zero(out, rng_cones, idx_eq)
+    Δs_from_Δz_offset_nonnegative(out, ds, z, rng_cones, idx_inq)
 
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
-        Δs_from_Δz_offset_soc!(out, ds, z, w, λ, η, rng_cones, n_shift, n_soc)
-    end
+        Δs_from_Δz_offset_soc(out, ds, z, w, λ, η, rng_cones, n_shift, n_soc)
 
-    n_nonsymmetric = n_exp+n_pow
-    if n_nonsymmetric > 0
+    n_nonsymmetric = n_exp + n_pow
+    if n_nonsymmetric > 0:
         n_shift = n_linear + n_soc
-        Δs_from_Δz_offset_nonsymmetric!(out, ds, rng_cones, n_shift, n_nonsymmetric)
-    end
+        Δs_from_Δz_offset_nonsymmetric(out, ds, rng_cones, n_shift, n_nonsymmetric)
 
-    if n_psd > 0
-        n_shift = n_linear+n_soc+n_exp+n_pow
-        Δs_from_Δz_offset_psd!(cones, out, ds, work, n_shift, n_psd)
-    end
+    if n_psd > 0:
+        n_shift = n_linear + n_soc + n_exp + n_pow
+        Δs_from_Δz_offset_psd(cones, out, ds, work, n_shift, n_psd)
 
-    return nothing
-end
+    return
 
-# maximum allowed step length over all cones
-function step_length(
-     cones::CompositeConeGPU{T},
-        dz::AbstractVector{T},
-        ds::AbstractVector{T},
-         z::AbstractVector{T},
-         s::AbstractVector{T},
-  settings::Settings{T},
-      αmax::T,
-) where {T}
+@njit
+def step_length_nonnegative(dz, ds, z, s, α, αmax, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        α[rng] = np.minimum(αmax, np.minimum(-z[rng] / dz[rng], -s[rng] / ds[rng]))
+        αmax = np.minimum(αmax, np.min(α[rng]))
+    return αmax
 
+@njit
+def step_length_soc(dz, ds, z, s, α, αmax, rng_cones, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        α[shift_i] = np.minimum(αmax, np.minimum(-z[rng[0]] / dz[rng[0]], -s[rng[0]] / ds[rng[0]]))
+        αmax = np.minimum(αmax, α[shift_i])
+    return αmax
+
+@njit
+def step_length_psd(dz, ds, Λisqrt, d, Rx, Rinv, workmat1, workmat2, workmat3, αmax, rng_cones, n_shift, n_psd):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        d[rng] = dz[rng]
+        αmax = np.minimum(αmax, step_length_psd_component(workmat1, d, Λisqrt, n_psd, αmax))
+        d[rng] = ds[rng]
+        αmax = np.minimum(αmax, step_length_psd_component(workmat1, d, Λisqrt, n_psd, αmax))
+    return αmax
+
+@njit
+def step_length_psd_component(workΔ, d, Λisqrt, n_psd, αmax):
+    workΔ = np.dot(Λisqrt, d)
+    e = np.linalg.eigvalsh(workΔ)
+    γ = np.min(e)
+    if γ < 0:
+        return np.minimum(1 / -γ, αmax)
+    else:
+        return αmax
+
+def step_length(cones, dz, ds, z, s, α, αmax):
     n_linear = cones.n_linear
     n_soc = cones.n_soc
-    n_exp = cones.n_exp
-    n_pow = cones.n_pow
     n_psd = cones.n_psd
-    rng_cones       = cones.rng_cones
+    rng_cones = cones.rng_cones
     idx_inq = cones.idx_inq
-    α               = cones.α
-    αp              = cones.αp
     Λisqrt = cones.Λisqrt
-    d      = cones.workvec
-    Rx     = cones.R
-    Rinv   = cones.Rinv
-    (workmat1, workmat2, workmat3) = (cones.workmat1, cones.workmat2, cones.workmat3)
-
-    CUDA.@sync @. α = αmax          #Initialize step size
+    d = cones.d
+    Rx = cones.R
+    Rinv = cones.Rinv
+    workmat1 = cones.workmat1
+    workmat2 = cones.workmat2
+    workmat3 = cones.workmat3
 
     αmax = step_length_nonnegative(dz, ds, z, s, α, αmax, rng_cones, idx_inq)
 
-    if n_soc > 0
+    if n_soc > 0:
         n_shift = n_linear
         αmax = step_length_soc(dz, ds, z, s, α, αmax, rng_cones, n_shift, n_soc)
-        if αmax < 0
-            throw(DomainError("starting point of line search not in SOC"))
-        end
-    end
 
-    if n_psd > 0
-        n_shift = n_linear+n_soc+n_exp+n_pow
+    if n_psd > 0:
+        n_shift = n_linear + n_soc
         αmax = step_length_psd(dz, ds, Λisqrt, d, Rx, Rinv, workmat1, workmat2, workmat3, αmax, rng_cones, n_shift, n_psd)
-        if αmax < 0
-            throw(DomainError("starting point of line search not in positive semidefinite cones"))
-        end
-    end
 
-    step = settings.linesearch_backtrack_step
-    αmin = settings.min_terminate_step_length
-    #if we have any nonsymmetric cones, then back off from full steps slightly
-    #so that centrality checks and logarithms don't fail right at the boundaries
-    if(n_exp + n_pow > 0)
-        αmax = min(αmax,settings.max_step_fraction)
-    end
-  
-    if n_exp > 0
-        n_shift = n_linear+n_soc
-        αmax = step_length_exp(dz, ds, z, s, α, rng_cones, αmax, αmin, step, n_shift, n_exp)
-        if αmax < 0
-            throw(DomainError("starting point of line search not in expotential cones"))
-        end
-    end
+    return αmax
 
-    if n_pow > 0
-        n_shift = n_linear+n_soc+n_exp
-        αmax = step_length_pow(dz,ds,z,s,α,αp,rng_cones,αmax,αmin,step,n_shift,n_pow)
-        if αmax < 0
-            throw(DomainError("starting point of line search not in power cones"))
-        end
-    end
+@njit
+def compute_barrier_nonnegative(barrier, z, s, dz, ds, α, rng_cones, idx_inq):
+    for i in idx_inq:
+        rng = rng_cones[i]
+        barrier[rng] = -np.log(z[rng] + α * dz[rng]) - np.log(s[rng] + α * ds[rng])
+    return np.sum(barrier)
 
-    return (αmax,αmax)
-end
+@njit
+def compute_barrier_soc(barrier, z, s, dz, ds, α, rng_cones, n_shift, n_soc):
+    for i in range(n_soc):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        zi = z[rng]
+        si = s[rng]
+        dzi = dz[rng]
+        dsi = ds[rng]
+        cur_z = zi + α * dzi
+        cur_s = si + α * dsi
+        barrier_d = -np.log(np.sqrt(cur_z[0]**2 - np.sum(cur_z[1:]**2)))
+        barrier_p = -np.log(np.sqrt(cur_s[0]**2 - np.sum(cur_s[1:]**2)))
+        barrier[shift_i] = barrier_d + barrier_p
+    return np.sum(barrier)
 
-# compute the total barrier function at the point (z + α⋅dz, s + α⋅ds)
-function compute_barrier(
-    cones::CompositeConeGPU{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-    α::T
-) where {T}
+@njit
+def compute_barrier_psd(barrier, z, s, dz, ds, α, workmat1, workvec, rng_cones, psd_dim, n_shift, n_psd):
+    for i in range(n_psd):
+        shift_i = i + n_shift
+        rng = rng_cones[shift_i]
+        dsi = ds[rng]
+        dzi = dz[rng]
+        zi = z[rng]
+        si = s[rng]
+        cur_z = zi + α * dzi
+        cur_s = si + α * dsi
+        Q = workmat1
+        q = workvec
+        q[rng] = cur_z
+        Q[i] = np.reshape(q[rng], (int(np.sqrt(len(q[rng]))), -1))
+        _, info = np.linalg.cholesky(Q[i])
+        if np.all(info == 0):
+            barrier_d = 2 * np.sum(np.log(np.diag(Q[i])))
+        else:
+            barrier_d = np.inf
+        q[rng] = cur_s
+        Q[i] = np.reshape(q[rng], (int(np.sqrt(len(q[rng]))), -1))
+        _, info = np.linalg.cholesky(Q[i])
+        if np.all(info == 0):
+            barrier_p = 2 * np.sum(np.log(np.diag(Q[i])))
+        else:
+            barrier_p = np.inf
+        barrier[shift_i] = -barrier_d - barrier_p
+    return np.sum(barrier)
 
+def compute_barrier(cones, barrier, z, s, dz, ds, α):
     n_linear = cones.n_linear
-    n_nn = cones.n_nn
     n_soc = cones.n_soc
-    n_exp = cones.n_exp
-    n_pow = cones.n_pow
     n_psd = cones.n_psd
-    psd_dim = cones.psd_dim
     rng_cones = cones.rng_cones
-    αp    = cones.αp
+    idx_inq = cones.idx_inq
     workmat1 = cones.workmat1
-    workvec  = cones.workvec
+    workvec = cones.workvec
+    psd_dim = cones.psd_dim
 
-    barrier = zero(T)
-    work = cones.α
-    
-    if n_nn > 0
-        val = compute_barrier_nonnegative(work, z, s, dz, ds, α, rng_cones, cones.idx_inq, n_nn)
-        barrier += val
-    end
+    barrier[:] = 0
 
-    if n_soc > 0
-        val = compute_barrier_soc(work, z, s, dz, ds, α, rng_cones, n_linear, n_soc)
-        barrier += val
-    end
+    barrier_sum = compute_barrier_nonnegative(barrier, z, s, dz, ds, α, rng_cones, idx_inq)
 
-    if n_exp > 0
-        n_shift = n_linear+n_soc
-        val = compute_barrier_exp(work, z, s, dz, ds, α, rng_cones, n_shift, n_exp)
-        barrier += val
-    end
+    if n_soc > 0:
+        n_shift = n_linear
+        barrier_sum += compute_barrier_soc(barrier, z, s, dz, ds, α, rng_cones, n_shift, n_soc)
 
-    if n_pow > 0
-        n_shift = n_linear+n_soc+n_exp
-        val = compute_barrier_pow(work, z, s, dz, ds, α, αp, rng_cones, n_shift, n_pow)
-        barrier += val
-    end
+    if n_psd > 0:
+        n_shift = n_linear + n_soc
+        barrier_sum += compute_barrier_psd(barrier, z, s, dz, ds, α, workmat1, workvec, rng_cones, psd_dim, n_shift, n_psd)
 
-    if n_psd > 0
-        n_shift = n_linear+n_soc+n_exp+n_pow
-        val = compute_barrier_psd(work, z, s, dz, ds, α, workmat1, workvec, rng_cones, psd_dim, n_shift, n_psd)
-        barrier += val
-    end
-
-    return barrier
-end
-
+    return barrier_sum

--- a/src/gpucones/coneops_expcone_gpu.jl
+++ b/src/gpucones/coneops_expcone_gpu.jl
@@ -1,662 +1,204 @@
-# # ----------------------------------------------------
-# # Exponential Cone
-# # ----------------------------------------------------
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
 
-# # degree of the cone.  Always 3
-# degree(K::ExponentialCone{T}) where {T} = 3
-# numel(K::ExponentialCone{T}) where {T} = 3
-
-# is_symmetric(::ExponentialCone{T}) where {T} = false
-
-# unit initialization for asymmetric solves
-function _kernel_unit_initialization_exp!(
-   z::AbstractVector{T},
-   s::AbstractVector{T},
-   rng_cones::AbstractVector,
-   n_shift::Cint,
-   n_exp::Cint
-) where{T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_exp
+@njit
+def unit_initialization_exp(z, s, rng_cones, n_shift, n_exp):
+    for i in range(n_exp):
         shift_i = i + n_shift
         rng_cone_i = rng_cones[shift_i]
-        @views zi = z[rng_cone_i] 
-        @views si = s[rng_cone_i] 
-        si[1] = T(-1.051383945322714)
-        si[2] = T(0.556409619469370)
-        si[3] = T(1.258967884768947)
-    
-        #@. z = s
-        @inbounds for j = 1:3
-            zi[j] = si[j]
-        end
-    end
+        s[rng_cone_i[0]] = -1.051383945322714
+        s[rng_cone_i[1]] = 0.556409619469370
+        s[rng_cone_i[2]] = 1.258967884768947
+        z[rng_cone_i] = s[rng_cone_i]
 
-    return nothing
-end
+@njit
+def update_Hs_exp(s, z, grad, Hs, H_dual, μ, scaling_strategy):
+    if scaling_strategy == "Dual":
+        Hs[:] = μ * H_dual
+    else:
+        use_primal_dual_scaling_exp(s, z, grad, Hs, H_dual)
 
-@inline function unit_initialization_exp!(
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_exp::Cint
- ) where{T}
- 
-    kernel = @cuda launch=false _kernel_unit_initialization_exp!(z, s, rng_cones, n_shift, n_exp)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_exp, config.threads)
-    blocks = cld(n_exp, threads)
-
-    CUDA.@sync kernel(z, s, rng_cones, n_shift, n_exp; threads, blocks)
- end
-
- # update the scaling matrix Hs
-@inline function update_Hs_exp(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractVector{T},
-    Hs::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    μ::T,
-    scaling_strategy::ScalingStrategy
-) where {T}
-
-    # Choose the scaling strategy
-    if(scaling_strategy == Dual::ScalingStrategy)
-        # Dual scaling: Hs = μ*H
-        use_dual_scaling_gpu(Hs,H_dual,μ)
-    else
-        # Primal-dual scaling
-        use_primal_dual_scaling_exp(s,z,grad,Hs,H_dual)
-    end 
-end
-
-function _kernel_update_scaling_exp!(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    Hs::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    rng_cones::AbstractVector,
-    μ::T,
-    scaling_strategy::ScalingStrategy,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_exp
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def update_scaling_exp(s, z, grad, Hs, H_dual, rng_cones, μ, scaling_strategy, n_shift, n_exp):
+    for i in range(n_exp):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views zi = z[rng_i] 
-        @views si = s[rng_i] 
-        @views gradi = grad[i,:]
-        @views Hsi = Hs[i,:,:]
-        @views Hi = H_dual[i,:,:]
+        zi = z[rng_i]
+        si = s[rng_i]
+        gradi = grad[i, :]
+        Hsi = Hs[i, :, :]
+        Hi = H_dual[i, :, :]
+        update_dual_grad_H_exp(gradi, Hi, zi)
+        update_Hs_exp(si, zi, gradi, Hsi, Hi, μ, scaling_strategy)
 
-        update_dual_grad_H_exp(gradi,Hi,zi)
-      
-        # update the scaling matrix Hs
-        update_Hs_exp(si,zi,gradi,Hsi,Hi,μ,scaling_strategy)
-        
-    end
-
-    return nothing
-end
-
-@inline function update_scaling_exp!(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    Hs::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    rng_cones::AbstractVector,
-    μ::T,
-    scaling_strategy::ScalingStrategy,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_update_scaling_exp!(s, z, grad, Hs, H_dual, rng_cones, μ, scaling_strategy, n_shift, n_exp)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_exp, config.threads)
-    blocks = cld(n_exp, threads)
-
-    CUDA.@sync kernel(s, z, grad, Hs, H_dual, rng_cones, μ, scaling_strategy, n_shift, n_exp; threads, blocks)
-end
-
-# return μH*(z) for exponential cone
-function _kernel_get_Hs_exp!(
-    Hsblock::AbstractVector{T},
-    Hs::AbstractArray{T},
-    rng_blocks::AbstractVector,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_exp
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def get_Hs_exp(Hsblocks, Hs, rng_blocks, n_shift, n_exp):
+    for i in range(n_exp):
         shift_i = i + n_shift
         rng_i = rng_blocks[shift_i]
-        @views Hsi = Hs[i,:,:]
-        @views Hsblocki = Hsblock[rng_i]
+        Hsblocks[rng_i] = Hs[i, :, :].flatten()
 
-        
-        @inbounds for j in 1:length(Hsblocki)
-            Hsblocki[j] = Hsi[j]
-        end
-    end
-
-    return nothing
-
-end
-
-@inline function get_Hs_exp!(
-    Hsblocks::AbstractVector{T},
-    Hs::AbstractArray{T},
-    rng_blocks::AbstractVector,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_get_Hs_exp!(Hsblocks, Hs, rng_blocks, n_shift, n_exp)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_exp, config.threads)
-    blocks = cld(n_exp, threads)
-
-    CUDA.@sync kernel(Hsblocks, Hs, rng_blocks, n_shift, n_exp; threads, blocks)
-end
-
-function _kernel_combined_ds_shift_exp!(
-    shift::AbstractVector{T},
-    step_z::AbstractVector{T},
-    step_s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    rng_cones::AbstractVector,
-    σμ::T,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_exp
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def combined_ds_shift_exp(shift, step_z, step_s, z, grad, H_dual, rng_cones, σμ, n_shift, n_exp):
+    for i in range(n_exp):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views Hi = H_dual[i,:,:]
-        @views gradi = grad[i,:]
-        @views zi = z[rng_i]
-        @views step_si = step_s[rng_i]
-        @views step_zi = step_z[rng_i]
-        @views shifti = shift[rng_i]
+        Hi = H_dual[i, :, :]
+        gradi = grad[i, :]
+        zi = z[rng_i]
+        step_si = step_s[rng_i]
+        step_zi = step_z[rng_i]
+        shifti = shift[rng_i]
+        η = np.zeros(3)
+        higher_correction_exp(Hi, zi, η, step_si, step_zi)
+        shifti[:] = gradi * σμ - η
 
-        η = @MVector T[0, 0, 0]
-
-        #3rd order correction requires input variables z
-        higher_correction_exp!(Hi,zi,η,step_si,step_zi)             
-
-        @inbounds for i = 1:3
-            shifti[i] = gradi[i]*σμ - η[i]
-        end
-    end
-
-    return nothing
-end
-
-@inline function combined_ds_shift_exp!(
-    shift::AbstractVector{T},
-    step_z::AbstractVector{T},
-    step_s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    rng_cones::AbstractVector,
-    σμ::T,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_combined_ds_shift_exp!(shift, step_z, step_s, z, grad, H_dual, rng_cones, σμ, n_shift, n_exp)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_exp, config.threads)
-    blocks = cld(n_exp, threads)
-
-    CUDA.@sync kernel(shift, step_z, step_s, z, grad, H_dual, rng_cones, σμ, n_shift, n_exp; threads, blocks)
-end
-
-# function Δs_from_Δz_offset!(
-#     K::ExponentialCone{T},
-#     out::AbstractVector{T},
-#     ds::AbstractVector{T},
-#     work::AbstractVector{T},
-#     z::AbstractVector{T}
-# ) where {T}
-
-#     @inbounds for i = 1:3
-#         out[i] = ds[i]
-#     end
-
-#     return nothing
-# end
-
-#return maximum step length while staying in exponential cone
-function _kernel_step_length_exp(
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-     z::AbstractVector{T},
-     s::AbstractVector{T},
-     α::AbstractVector{T},
-     rng_cones::AbstractVector,
-     αmax::T,
-     αmin::T,
-     step::T,
-     n_shift::Cint,
-     n_exp::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_exp
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def step_length_exp(dz, ds, z, s, α, rng_cones, αmax, αmin, step, n_shift, n_exp):
+    for i in range(n_exp):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views dzi = dz[rng_i]
-        @views dsi = ds[rng_i]
-        @views zi = z[rng_i]
-        @views si = s[rng_i]
-        
+        dzi = dz[rng_i]
+        dsi = ds[rng_i]
+        zi = z[rng_i]
+        si = s[rng_i]
         α[i] = backtrack_search_exp(dzi, zi, dsi, si, αmax, αmin, step)
-    end
+    return min(αmax, np.min(α[:n_exp]))
 
-    return nothing
-end
-
-@inline function step_length_exp(
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-     z::AbstractVector{T},
-     s::AbstractVector{T},
-     α::AbstractVector{T},
-     rng_cones::AbstractVector,
-     αmax::T,
-     αmin::T,
-     step::T,
-     n_shift::Cint,
-     n_exp::Cint
-) where {T}
-    kernel = @cuda launch=false _kernel_step_length_exp(dz, ds, z, s, α, rng_cones, αmax, αmin, step, n_shift, n_exp)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_exp, config.threads)
-    blocks = cld(n_exp, threads)
-
-    CUDA.@sync kernel(dz, ds, z, s, α, rng_cones, αmax, αmin, step, n_shift, n_exp; threads, blocks)
-    @views αmax = min(αmax, minimum(α[1:n_exp]))
-
-    return αmax
-end
-
-@inline function backtrack_search_exp(
-    dz::AbstractVector{T},
-    z::AbstractVector{T},
-    ds::AbstractVector{T},
-    s::AbstractVector{T},
-    α_init::T,
-    α_min::T,
-    step::T
-) where {T}
-
-    α = α_init
-    work = @MVector T[0, 0, 0]
-    
-    while true
-        #@. wq = q + α*dq
-        @inbounds for i in eachindex(work)
-            work[i] = s[i] + α*ds[i]
-        end
-
-        if is_primal_feasible_exp(work)
+@njit
+def backtrack_search_exp(dzi, zi, dsi, si, αmax, αmin, step):
+    α = αmax
+    work = np.zeros(3)
+    while True:
+        work[:] = si + α * dsi
+        if is_primal_feasible_exp(work):
             break
-        end
-        if (α *= step) < α_min
-            α = zero(T)
-            return α
-        end
-    end
-
-    while true
-        #@. wq = q + α*dq
-        @inbounds for i in eachindex(work)
-            work[i] = z[i] + α*dz[i]
-        end
-
-        if is_dual_feasible_exp(work)
+        if (α := α * step) < αmin:
+            return 0.0
+    while True:
+        work[:] = zi + α * dzi
+        if is_dual_feasible_exp(work):
             break
-        end
-        if (α *= step) < α_min
-            α = zero(T)
-            return α
-        end
-    end
-
+        if (α := α * step) < αmin:
+            return 0.0
     return α
-end
 
-function _kernel_compute_barrier_exp(
-    barrier::AbstractVector{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-    α::T,
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
-
-    # we want to avoid allocating a vector for the intermediate 
-    # sums, so the two barrier functions are written to accept 
-    # both vectors and 3-element tuples. 
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_exp
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def compute_barrier_exp(barrier, z, s, dz, ds, α, rng_cones, n_shift, n_exp):
+    for i in range(n_exp):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views dzi = dz[rng_i]
-        @views dsi = ds[rng_i]
-        @views zi = z[rng_i]
-        @views si = s[rng_i]
-        
-        cur_z    = @MVector [zi[1] + α*dzi[1], zi[2] + α*dzi[2], zi[3] + α*dzi[3]]
-        cur_s    = @MVector [si[1] + α*dsi[1], si[2] + α*dsi[2], si[3] + α*dsi[3]]
-    
+        dzi = dz[rng_i]
+        dsi = ds[rng_i]
+        zi = z[rng_i]
+        si = s[rng_i]
+        cur_z = zi + α * dzi
+        cur_s = si + α * dsi
         barrier_d = barrier_dual_exp(cur_z)
         barrier_p = barrier_primal_exp(cur_s)
         barrier[i] = barrier_d + barrier_p
-    end
+    return np.sum(barrier[:n_exp])
 
-    return nothing
-end
+@njit
+def barrier_dual_exp(z):
+    l = np.log(-z[2] / z[0])
+    return -np.log(-z[2] * z[0]) - np.log(z[1] - z[0] - z[0] * l)
 
-@inline function compute_barrier_exp(
-    barrier::AbstractVector{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-    α::T,
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_exp::Cint
-) where {T}
+@njit
+def barrier_primal_exp(s):
+    ω = _wright_omega(1 - s[0] / s[1] - np.log(s[1] / s[2]))
+    ω = (ω - 1) * (ω - 1) / ω
+    return -np.log(ω) - 2 * np.log(s[1]) - np.log(s[2]) - 3
 
+@njit
+def is_primal_feasible_exp(s):
+    if s[2] > 0 and s[1] > 0:
+        res = s[1] * np.log(s[2] / s[1]) - s[0]
+        if res > 0:
+            return True
+    return False
 
-    kernel = @cuda launch=false _kernel_compute_barrier_exp(barrier,z,s,dz,ds,α,rng_cones,n_shift,n_exp)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_exp, config.threads)
-    blocks = cld(n_exp, threads)
+@njit
+def is_dual_feasible_exp(z):
+    if z[2] > 0 and z[0] < 0:
+        res = z[1] - z[0] - z[0] * np.log(-z[2] / z[0])
+        if res > 0:
+            return True
+    return False
 
-    CUDA.@sync kernel(barrier,z,s,dz,ds,α,rng_cones,n_shift,n_exp; threads, blocks)
+@njit
+def gradient_primal_exp(s):
+    ω = _wright_omega(1 - s[0] / s[1] - np.log(s[1] / s[2]))
+    g1 = 1 / ((ω - 1) * s[1])
+    g2 = g1 + g1 * np.log(ω * s[1] / s[2]) - 1 / s[1]
+    g3 = ω / ((1 - ω) * s[2])
+    return np.array([g1, g2, g3])
 
-    return sum(@view barrier[1:n_exp])
-end
+@njit
+def higher_correction_exp(H, z, η, ds, v):
+    u = np.linalg.solve(H, ds)
+    η[1] = 1
+    η[2] = -z[0] / z[2]
+    η[0] = np.log(η[2])
+    ψ = z[0] * η[0] - z[0] + z[1]
+    dotψu = np.dot(η, u)
+    dotψv = np.dot(η, v)
+    coef = ((u[0] * (v[0] / z[0] - v[2] / z[2]) + u[2] * (z[0] * v[2] / z[2] - v[0]) / z[2]) * ψ - 2 * dotψu * dotψv) / (ψ * ψ * ψ)
+    η *= coef
+    inv_ψ2 = 1 / (ψ * ψ)
+    η[0] += (1 / ψ - 2 / z[0]) * u[0] * v[0] / (z[0] * z[0]) - u[2] * v[2] / (z[2] * z[2]) / ψ + dotψu * inv_ψ2 * (v[0] / z[0] - v[2] / z[2]) + dotψv * inv_ψ2 * (u[0] / z[0] - u[2] / z[2])
+    η[2] += 2 * (z[0] / ψ - 1) * u[2] * v[2] / (z[2] * z[2] * z[2]) - (u[2] * v[0] + u[0] * v[2]) / (z[2] * z[2]) / ψ + dotψu * inv_ψ2 * (z[0] * v[2] / (z[2] * z[2]) - v[0] / z[2]) + dotψv * inv_ψ2 * (z[0] * u[2] / (z[2] * z[2]) - u[0] / z[2])
+    η /= 2
 
+@njit
+def update_dual_grad_H_exp(grad, H, z):
+    l = np.log(-z[2] / z[0])
+    r = -z[0] * l - z[0] + z[1]
+    c2 = 1 / r
+    grad[0] = c2 * l - 1 / z[0]
+    grad[1] = -c2
+    grad[2] = (c2 * z[0] - 1) / z[2]
+    H[0, 0] = ((r * r - z[0] * r + l * l * z[0] * z[0]) / (r * z[0] * z[0] * r))
+    H[0, 1] = (-l / (r * r))
+    H[1, 0] = H[0, 1]
+    H[1, 1] = (1 / (r * r))
+    H[0, 2] = ((z[1] - z[0]) / (r * r * z[2]))
+    H[2, 0] = H[0, 2]
+    H[1, 2] = (-z[0] / (r * r * z[2]))
+    H[2, 1] = H[1, 2]
+    H[2, 2] = ((r * r - z[0] * r + z[0] * z[0]) / (r * r * z[2] * z[2]))
 
-# # -----------------------------------------
-# # nonsymmetric cone operations for exponential cones
-# #
-# # Primal exponential cone: s3 ≥ s2*e^(s1/s2), s3,s2 > 0
-# # Dual exponential cone: z3 ≥ -z1*e^(z2/z1 - 1), z3 > 0, z1 < 0
-# # We use the dual barrier function: 
-# # f*(z) = -log(z2 - z1 - z1*log(z3/-z1)) - log(-z1) - log(z3)
-# # -----------------------------------------
-
-
-@inline function barrier_dual_exp(
-    z::AbstractVector{T}
-) where {T}
-
-    # Dual barrier
-    l = logsafe(-z[3]/z[1])
-    return -logsafe(-z[3]*z[1]) - logsafe(z[2]-z[1]-z[1]*l) 
-
-end 
-
-@inline function barrier_primal_exp(
-    s::AbstractVector{T}
-) where {T}
-
-    # Primal barrier: 
-    # f(s) = ⟨s,g(s)⟩ - f*(-g(s))
-    #      = -2*log(s2) - log(s3) - log((1-barω)^2/barω) - 3, 
-    # where barω = ω(1 - s1/s2 - log(s2) - log(s3))
-    # NB: ⟨s,g(s)⟩ = -3 = - ν
-
-    ω = _wright_omega_gpu(1-s[1]/s[2]-logsafe(s[2]/s[3]))
-    ω = (ω-1)*(ω-1)/ω
-   return -logsafe(ω)-2*logsafe(s[2])-logsafe(s[3]) - 3
-end 
-
-
-
-# Returns true if s is primal feasible
-@inline function is_primal_feasible_exp(
-    s::AbstractVector{T}
-) where {T}
-
-    if (s[3] > 0 && s[2] > zero(T))   #feasible
-        res = s[2]*logsafe(s[3]/s[2]) - s[1]
-        if (res > zero(T))
-            return true
-        end
-    end
-
-    return false
-end
-
-# Returns true if z is dual feasible
-@inline function is_dual_feasible_exp(
-    z::AbstractVector{T}
-) where {T}
-
-    if (z[3] > 0 && z[1] < zero(T))
-        res = z[2] - z[1] - z[1]*logsafe(-z[3]/z[1])
-        if (res > zero(T))
-            return true
-        end
-    end
-    return false
-end
-
-# Compute the primal gradient of f(s) at s
-function gradient_primal_exp(
-    s::Union{AbstractVector{T}, NTuple{3,T}},
-) where {T}
-
-    ω = _wright_omega_gpu(1-s[1]/s[2]-logsafe(s[2]/s[3]))
-    @assert isfinite(ω)
-
-    g1 = one(T)/((ω-one(T))*s[2])
-    g2 = g1 + g1*logsafe(ω*s[2]/s[3]) - one(T)/s[2]
-    g3 = ω/((one(T) - ω)*s[3])
-
-    return SVector(g1,g2,g3)
-
-end
-
-# # 3rd-order correction at the point z.  Output is η.
-# #
-# # η = -0.5*[(dot(u,Hψ,v)*ψ - 2*dotψu*dotψv)/(ψ*ψ*ψ)*gψ + 
-# #      dotψu/(ψ*ψ)*Hψv + dotψv/(ψ*ψ)*Hψu - dotψuv/ψ + dothuv]
-# #
-# # where :
-# # Hψ = [  1/z[1]    0   -1/z[3];
-# #           0       0   0;
-# #         -1/z[3]   0   z[1]/(z[3]*z[3]);]
-# # dotψuv = [-u[1]*v[1]/(z[1]*z[1]) + u[3]*v[3]/(z[3]*z[3]); 
-# #            0; 
-# #           (u[3]*v[1]+u[1]*v[3])/(z[3]*z[3]) - 2*z[1]*u[3]*v[3]/(z[3]*z[3]*z[3])]
-# #
-# # dothuv = [-2*u[1]*v[1]/(z[1]*z[1]*z[1]) ; 
-# #            0; 
-# #           -2*u[3]*v[3]/(z[3]*z[3]*z[3])]
-# # Hψv = Hψ*v
-# # Hψu = Hψ*u
-# #gψ is used inside η
-
-@inline function higher_correction_exp!(
-    H::AbstractArray{T},
-    z::AbstractVector{T},
-    η::AbstractVector{T},
-    ds::AbstractVector{T},
-    v::AbstractVector{T}
-) where {T}
- 
-    #solve H*u = ds
-    cholH = @MArray T[0.0 0.0 0.0;0.0 0.0 0.0;0.0 0.0 0.0]
-    issuccess = cholesky_3x3_explicit_factor!(cholH,H)
-    if issuccess 
-        u = cholesky_3x3_explicit_solve!(cholH,ds)
-    else 
-        return SVector(zero(T),zero(T),zero(T))
-    end
-    
-    η[2] = one(T)
-    η[3] = -z[1]/z[3]    # gradient of ψ
-    η[1] = logsafe(η[3])
-
-    ψ = z[1]*η[1]-z[1]+z[2]
-
-    dotψu = _dot_xy_gpu(η,u,1:3)
-    dotψv = _dot_xy_gpu(η,v,1:3)
-
-    coef = ((u[1]*(v[1]/z[1] - v[3]/z[3]) + u[3]*(z[1]*v[3]/z[3] - v[1])/z[3])*ψ - 2*dotψu*dotψv)/(ψ*ψ*ψ)
-    @inbounds for i = 1:3
-        η[i] *= coef
-    end
-
-    inv_ψ2 = one(T)/ψ/ψ
-
-    # efficient implementation for η above
-    η[1] += (1/ψ - 2/z[1])*u[1]*v[1]/(z[1]*z[1]) - u[3]*v[3]/(z[3]*z[3])/ψ + dotψu*inv_ψ2*(v[1]/z[1] - v[3]/z[3]) + dotψv*inv_ψ2*(u[1]/z[1] - u[3]/z[3])
-    η[3] += 2*(z[1]/ψ-1)*u[3]*v[3]/(z[3]*z[3]*z[3]) - (u[3]*v[1]+u[1]*v[3])/(z[3]*z[3])/ψ + dotψu*inv_ψ2*(z[1]*v[3]/(z[3]*z[3]) - v[1]/z[3]) + dotψv*inv_ψ2*(z[1]*u[3]/(z[3]*z[3]) - u[1]/z[3])
-
-    @inbounds for i = 1:3
-        η[i] /= 2
-    end
-
-    # coercing to an SArray means that the MArray we computed 
-    # locally in this function is seemingly not heap allocated 
-    SVector(η)
-end
-
-
-# update gradient and Hessian at dual z
-@inline function update_dual_grad_H_exp(
-    grad::AbstractVector{T},
-    H::AbstractArray{T},
-    z::AbstractVector{T}
-) where {T}
-
-    l = logsafe(-z[3]/z[1])
-    r = -z[1]*l-z[1]+z[2]
-
-    # compute the gradient at z
-    c2 = one(T)/r
-
-    grad[1] = c2*l - 1/z[1]
-    grad[2] = -c2
-    grad[3] = (c2*z[1]-1)/z[3]
-
-    # compute the Hessian at z
-    H[1,1] = ((r*r-z[1]*r+l*l*z[1]*z[1])/(r*z[1]*z[1]*r))
-    H[1,2] = (-l/(r*r))
-    H[2,1] = H[1,2]
-    H[2,2] = (1/(r*r))
-    H[1,3] = ((z[2]-z[1])/(r*r*z[3]))
-    H[3,1] = H[1,3]
-    H[2,3] = (-z[1]/(r*r*z[3]))
-    H[3,2] = H[2,3]
-    H[3,3] = ((r*r-z[1]*r+z[1]*z[1])/(r*r*z[3]*z[3])) 
-    
-    return nothing
-end
-
-
-
-# # ω(z) is the Wright-Omega function
-# # Computes the value ω(z) defined as the solution y to
-# # y+log(y) = z for reals z>=1.
-# #
-# # Follows Algorithm 4, §8.4 of thesis of Santiago Serrango:
-# #  Algorithms for Unsymmetric Cone Optimization and an
-# #  Implementation for Problems with the Exponential Cone 
-# #  https://web.stanford.edu/group/SOL/dissertations/ThesisAkleAdobe-augmented.pdf
-
-function _wright_omega_gpu(z::T) where {T}
-
-    if z < zero(T)
-        return Inf
-    end
-
-   if z < one(T) + T(π)     
-        #Initialize with the taylor series
-        zm1 = z - one(T)
-        p = zm1            #(z-1)
-        w = 1+0.5*p
-        p *= zm1         #(z-1)^2
-        w += (1/16.0)*p
-        p *= zm1          #(z-1)^3
-        w -= (1/192.0)*p
-        p *= zm1          #(z-1)^4
-        w -= (1/3072.0)*p
-        p *= zm1         #(z-1)^5
-        w += (13/61440.0)*p
-    else
-        # Initialize with:
-        # w(z) = z - log(z) + 
-        #        log(z)/z + 
-        #        log(z)/z^2(log(z)/2-1) + 
-        #        log(z)/z^3(1/3log(z)^2-3/2log(z)+1)
-
-        logz = logsafe(z)
-        zinv = inv(z)
+@njit
+def _wright_omega(z):
+    if z < 0:
+        return np.inf
+    if z < 1 + np.pi:
+        zm1 = z - 1
+        p = zm1
+        w = 1 + 0.5 * p
+        p *= zm1
+        w += (1 / 16.0) * p
+        p *= zm1
+        w -= (1 / 192.0) * p
+        p *= zm1
+        w -= (1 / 3072.0) * p
+        p *= zm1
+        w += (13 / 61440.0) * p
+    else:
+        logz = np.log(z)
+        zinv = 1 / z
         w = z - logz
-
-        # add log(z)/z 
-        q = logz*zinv  # log(z)/z 
+        q = logz * zinv
         w += q
-
-        # add log(z)/z^2(log(z)/2-1)
-        q *= zinv      # log(z)/(z^2) 
-        w += q * (logz/2 - one(T))
-
-        # add log(z)/z^3(1/3log(z)^2-3/2log(z)+1)
-        q * zinv       # log(z)/(z^3) 
-        w += q * (logz*logz/3. - (3/2.)*logz + one(T))
-
-    end
-
-    # Initialize the residual
-    r = z - w - logsafe(w)
-
-    # Santiago suggests two refinement iterations only
-    @inbounds for i = 1:2
-        wp1 = (w + one(T))
-        t = wp1 * (wp1 + (2. * r)/3.0 )
-        w *= 1 + (r/wp1) * ( t - 0.5 * r) / (t - r)
-        r = (2*w*w-8*w-1)/(72.0*(wp1*wp1*wp1*wp1*wp1*wp1))*r*r*r*r
-    end 
-
+        q *= zinv
+        w += q * (logz / 2 - 1)
+        q *= zinv
+        w += q * (logz * logz / 3.0 - (3 / 2.0) * logz + 1)
+    r = z - w - np.log(w)
+    for _ in range(2):
+        wp1 = w + 1
+        t = wp1 * (wp1 + (2 * r) / 3.0)
+        w *= 1 + (r / wp1) * (t - 0.5 * r) / (t - r)
+        r = (2 * w * w - 8 * w - 1) / (72.0 * (wp1 * wp1 * wp1 * wp1 * wp1 * wp1)) * r * r * r * r
     return w
-end

--- a/src/gpucones/coneops_powcone_gpu.jl
+++ b/src/gpucones/coneops_powcone_gpu.jl
@@ -1,703 +1,208 @@
-# # ----------------------------------------------------
-# # Power Cone
-# # ----------------------------------------------------
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
 
-# # degree of the cone is always 3 for PowerCone
-# degree(K::PowerCone{T}) where {T} = 3
-# numel(K::PowerCone{T}) where {T} = 3
-
-# is_symmetric(::PowerCone{T}) where {T} = false
-
-# unit initialization for asymmetric solves
-function _kernel_unit_initialization_pow!(
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_pow::Cint
-) where{T}
- 
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_pow
+@njit
+def unit_initialization_pow(z, s, αp, rng_cones, n_shift, n_pow):
+    for i in range(n_pow):
         shift_i = i + n_shift
         rng_cone_i = rng_cones[shift_i]
-        @views zi = z[rng_cone_i] 
-        @views si = s[rng_cone_i] 
-        si[1] = sqrt(one(T)+αp[i])
-        si[2] = sqrt(one(T)+((one(T)-αp[i])))
-        si[3] = zero(T)
+        si = s[rng_cone_i]
+        si[0] = np.sqrt(1 + αp[i])
+        si[1] = np.sqrt(1 + (1 - αp[i]))
+        si[2] = 0
+        z[rng_cone_i] = si
 
-        #@. z = s
-        @inbounds for j = 1:3
-            zi[j] = si[j]
-        end
-    end
+@njit
+def update_Hs_pow(s, z, grad, Hs, H_dual, μ, scaling_strategy, α):
+    if scaling_strategy == "Dual":
+        Hs[:] = μ * H_dual
+    else:
+        use_primal_dual_scaling_pow(s, z, grad, Hs, H_dual, α)
 
-    return nothing
-end
-
-@inline function unit_initialization_pow!(
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_pow::Cint
-) where{T}
- 
-    kernel = @cuda launch=false _kernel_unit_initialization_pow!(z, s, αp, rng_cones, n_shift, n_pow)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_pow, config.threads)
-    blocks = cld(n_pow, threads)
-
-    CUDA.@sync kernel(z, s, αp, rng_cones, n_shift, n_pow; threads, blocks)
-end
-
-# update the scaling matrix Hs
-@inline function update_Hs_pow(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractVector{T},
-    Hs::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    μ::T,
-    scaling_strategy::ScalingStrategy,
-    α::T
-) where {T}
-
-    # Choose the scaling strategy
-    if(scaling_strategy == Dual::ScalingStrategy)
-        # Dual scaling: Hs = μ*H
-        use_dual_scaling_gpu(Hs,H_dual,μ)
-    else
-        # Primal-dual scaling
-        use_primal_dual_scaling_pow(s,z,grad,Hs,H_dual,α)
-    end 
-end
-
-function _kernel_update_scaling_pow!(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    Hs::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    μ::T,
-    scaling_strategy::ScalingStrategy,
-    n_shift::Cint,
-    n_exp::Cint,
-    n_pow::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_pow
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def update_scaling_pow(s, z, grad, Hs, H_dual, αp, rng_cones, μ, scaling_strategy, n_shift, n_exp, n_pow):
+    for i in range(n_pow):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views zi = z[rng_i] 
-        @views si = s[rng_i] 
-        shift_exp = n_exp+i
-        @views gradi = grad[shift_exp,:]
-        @views Hsi = Hs[shift_exp,:,:]
-        @views Hi = H_dual[shift_exp,:,:]
-        # update both gradient and Hessian for function f*(z) at the point z
-        update_dual_grad_H_pow(gradi,Hi,zi,αp[i])
+        zi = z[rng_i]
+        si = s[rng_i]
+        shift_exp = n_exp + i
+        gradi = grad[shift_exp]
+        Hsi = Hs[shift_exp]
+        Hi = H_dual[shift_exp]
+        update_dual_grad_H_pow(gradi, Hi, zi, αp[i])
+        update_Hs_pow(si, zi, gradi, Hsi, Hi, μ, scaling_strategy, αp[i])
 
-        # update the scaling matrix Hs
-        update_Hs_pow(si,zi,gradi,Hsi,Hi,μ,scaling_strategy,αp[i])
-    end
-
-    return nothing
-end
-
-@inline function update_scaling_pow!(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    Hs::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    μ::T,
-    scaling_strategy::ScalingStrategy,
-    n_shift::Cint,
-    n_exp::Cint,
-    n_pow::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_update_scaling_pow!(s, z, grad, Hs, H_dual, αp, rng_cones, μ, scaling_strategy, n_shift, n_exp, n_pow)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_pow, config.threads)
-    blocks = cld(n_pow, threads)
-
-    CUDA.@sync kernel(s, z, grad, Hs, H_dual, αp, rng_cones, μ, scaling_strategy, n_shift, n_exp, n_pow; threads, blocks)
-end
-
-# return μH*(z) for power cone
-function _kernel_get_Hs_pow!(
-    Hsblock::AbstractVector{T},
-    Hs::AbstractArray{T},
-    rng_blocks::AbstractVector,
-    n_shift::Cint,
-    n_exp::Cint,
-    n_pow::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_pow
+@njit
+def get_Hs_pow(Hsblocks, Hs, rng_blocks, n_shift, n_exp, n_pow):
+    for i in range(n_pow):
         shift_i = i + n_shift
         rng_i = rng_blocks[shift_i]
-        shift_exp = n_exp+i
-        @views Hsi = Hs[shift_exp,:,:]
-        @views Hsblocki = Hsblock[rng_i]
+        shift_exp = n_exp + i
+        Hsblocks[rng_i] = Hs[shift_exp].flatten()
 
-        
-        @inbounds for j in 1:length(Hsblocki)
-            Hsblocki[j] = Hsi[j]
-        end
-    end
-
-    return nothing
-
-end
-
-@inline function get_Hs_pow!(
-    Hsblocks::AbstractVector{T},
-    Hs::AbstractArray{T},
-    rng_blocks::AbstractVector,
-    n_shift::Cint,
-    n_exp::Cint,
-    n_pow::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_get_Hs_pow!(Hsblocks, Hs, rng_blocks, n_shift, n_exp, n_pow)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_pow, config.threads)
-    blocks = cld(n_pow, threads)
-
-    CUDA.@sync kernel(Hsblocks, Hs, rng_blocks, n_shift, n_exp, n_pow; threads, blocks)
-end
-
-# # compute the product y = Hₛx = μH(z)x
-# function mul_Hs!(
-#     K::PowerCone{T},
-#     y::AbstractVector{T},
-#     x::AbstractVector{T},
-#     workz::AbstractVector{T}
-# ) where {T}
-
-#     # mul!(ls,K.Hs,lz,-one(T),zero(T))
-#     H = K.Hs
-#     @inbounds for i = 1:3
-#         y[i] =  H[i,1]*x[1] + H[i,2]*x[2] + H[i,3]*x[3]
-#     end
-
-# end
-
-function _kernel_combined_ds_shift_pow!(
-    shift::AbstractVector{T},
-    step_z::AbstractVector{T},
-    step_s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    σμ::T,
-    n_shift::Cint,
-    n_exp::Cint,
-    n_pow::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_pow
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def combined_ds_shift_pow(shift, step_z, step_s, z, grad, H_dual, αp, rng_cones, σμ, n_shift, n_exp, n_pow):
+    for i in range(n_pow):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
         shift_exp = i + n_exp
-        @views Hi = H_dual[shift_exp,:,:]
-        @views gradi = grad[shift_exp,:]
-        @views zi = z[rng_i]
-        @views step_si = step_s[rng_i]
-        @views step_zi = step_z[rng_i]
-        @views shifti = shift[rng_i]
+        Hi = H_dual[shift_exp]
+        gradi = grad[shift_exp]
+        zi = z[rng_i]
+        step_si = step_s[rng_i]
+        step_zi = step_z[rng_i]
+        shifti = shift[rng_i]
 
-        η = @MVector T[0, 0, 0]
+        η = np.zeros(3)
+        higher_correction_pow(Hi, zi, η, step_si, step_zi, αp[i])
+        shifti[:] = gradi * σμ - η
 
-        #3rd order correction requires input variables z
-        higher_correction_pow!(Hi,zi,η,step_si,step_zi,αp[i])             
-
-        @inbounds for i = 1:3
-            shifti[i] = gradi[i]*σμ - η[i]
-        end
-    end
-
-    return nothing
-end
-
-@inline function combined_ds_shift_pow!(
-    shift::AbstractVector{T},
-    step_z::AbstractVector{T},
-    step_s::AbstractVector{T},
-    z::AbstractVector{T},
-    grad::AbstractArray{T},
-    H_dual::AbstractArray{T},
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    σμ::T,
-    n_shift::Cint,
-    n_exp::Cint,
-    n_pow::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_combined_ds_shift_pow!(shift, step_z, step_s, z, grad, H_dual, αp, rng_cones, σμ, n_shift, n_exp, n_pow)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_pow, config.threads)
-    blocks = cld(n_pow, threads)
-
-    CUDA.@sync kernel(shift, step_z, step_s, z, grad, H_dual, αp, rng_cones, σμ, n_shift, n_exp, n_pow; threads, blocks)
-end
-
-# function Δs_from_Δz_offset!(
-#     K::PowerCone{T},
-#     out::AbstractVector{T},
-#     ds::AbstractVector{T},
-#     work::AbstractVector{T},
-#     z::AbstractVector{T}
-# ) where {T}
-
-#     @inbounds for i = 1:3
-#         out[i] = ds[i]
-#     end
-
-#     return nothing
-# end
-
-#return maximum allowable step length while remaining in the Power cone
-function _kernel_step_length_pow(
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-     z::AbstractVector{T},
-     s::AbstractVector{T},
-     α::AbstractVector{T},
-     αp::AbstractVector{T},
-     rng_cones::AbstractVector,
-     αmax::T,
-     αmin::T,
-     step::T,
-     n_shift::Cint,
-     n_pow::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_pow
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def step_length_pow(dz, ds, z, s, α, αp, rng_cones, αmax, αmin, step, n_shift, n_pow):
+    for i in range(n_pow):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views dzi = dz[rng_i]
-        @views dsi = ds[rng_i]
-        @views zi = z[rng_i]
-        @views si = s[rng_i]
-        
-        α[i]  = backtrack_search_pow(dzi, zi, dsi, si, αmax, αmin, step,αp[i])
-    end
-    
-    return nothing
-end
+        dzi = dz[rng_i]
+        dsi = ds[rng_i]
+        zi = z[rng_i]
+        si = s[rng_i]
+        α[i] = backtrack_search_pow(dzi, zi, dsi, si, αmax, αmin, step, αp[i])
+    return min(αmax, np.min(α[:n_pow]))
 
-@inline function step_length_pow(
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-     z::AbstractVector{T},
-     s::AbstractVector{T},
-     α::AbstractVector{T},
-     αp::AbstractVector{T},
-     rng_cones::AbstractVector,
-     αmax::T,
-     αmin::T,
-     step::T,
-     n_shift::Cint,
-     n_pow::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_step_length_pow(dz,ds,z,s,α,αp,rng_cones,αmax,αmin,step,n_shift,n_pow)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_pow, config.threads)
-    blocks = cld(n_pow, threads)
-
-    CUDA.@sync kernel(dz,ds,z,s,α,αp,rng_cones,αmax,αmin,step,n_shift,n_pow; threads, blocks)
-    @views αmax = min(αmax,minimum(α[1:n_pow]))
-
-    return αmax
-end
-
-@inline function backtrack_search_pow(
-    dz::AbstractVector{T},
-    z::AbstractVector{T},
-    ds::AbstractVector{T},
-    s::AbstractVector{T},
-    α_init::T,
-    α_min::T,
-    step::T,
-    αp::T
-) where {T}
-
-    α = α_init
-    work = @MVector T[0, 0, 0]
- 
-    while true
-        #@. wq = q + α*dq
-        @inbounds for i in eachindex(work)
-            work[i] = z[i] + α*dz[i]
-        end
-
-        if is_dual_feasible_pow(work,αp)
+@njit
+def backtrack_search_pow(dzi, zi, dsi, si, αmax, αmin, step, αp):
+    α = αmax
+    work = np.zeros(3)
+    while True:
+        work[:] = zi + α * dzi
+        if is_dual_feasible_pow(work, αp):
             break
-        end
-        if (α *= step) < α_min
-            α = zero(T)
-            return α
-        end
-    end
-    
-    while true
-        #@. wq = q + α*dq
-        @inbounds for i in eachindex(work)
-            work[i] = s[i] + α*ds[i]
-        end
-
-        if is_primal_feasible_pow(work,αp)
+        if (α := α * step) < αmin:
+            return 0.0
+    while True:
+        work[:] = si + α * dsi
+        if is_primal_feasible_pow(work, αp):
             break
-        end
-        if (α *= step) < α_min
-            α = zero(T)
-            return α
-        end
-    end
-
+        if (α := α * step) < αmin:
+            return 0.0
     return α
-end
 
-
-function _kernel_compute_barrier_pow(
-    barrier::AbstractVector{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-    α::T,
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_pow::Cint
-) where {T}
-
-    # we want to avoid allocating a vector for the intermediate 
-    # sums, so the two barrier functions are written to accept 
-    # both vectors and 3-element tuples. 
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_pow
-        # update both gradient and Hessian for function f*(z) at the point z
+@njit
+def compute_barrier_pow(barrier, z, s, dz, ds, α, αp, rng_cones, n_shift, n_pow):
+    for i in range(n_pow):
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views dzi = dz[rng_i]
-        @views dsi = ds[rng_i]
-        @views zi = z[rng_i]
-        @views si = s[rng_i]
-        
-        cur_z    = @MVector [zi[1] + α*dzi[1], zi[2] + α*dzi[2], zi[3] + α*dzi[3]]
-        cur_s    = @MVector [si[1] + α*dsi[1], si[2] + α*dsi[2], si[3] + α*dsi[3]]
-    
+        dzi = dz[rng_i]
+        dsi = ds[rng_i]
+        zi = z[rng_i]
+        si = s[rng_i]
+        cur_z = zi + α * dzi
+        cur_s = si + α * dsi
         barrier_d = barrier_dual_pow(cur_z, αp[i])
         barrier_p = barrier_primal_pow(cur_s, αp[i])
         barrier[i] = barrier_d + barrier_p
-    end
+    return np.sum(barrier[:n_pow])
 
-    return nothing
-end
+@njit
+def barrier_dual_pow(z, α):
+    return -np.log(-z[2] * z[0]) - np.log(z[1] - z[0] - z[0] * np.log(-z[2] / z[0]))
 
-@inline function compute_barrier_pow(
-    barrier::AbstractVector{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-    α::T,
-    αp::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_pow::Cint
-) where {T}
+@njit
+def barrier_primal_pow(s, α):
+    ω = _wright_omega(1 - s[0] / s[1] - np.log(s[1] / s[2]))
+    ω = (ω - 1) * (ω - 1) / ω
+    return -np.log(ω) - 2 * np.log(s[1]) - np.log(s[2]) - 3
 
+@njit
+def is_primal_feasible_pow(s, α):
+    if s[2] > 0 and s[1] > 0:
+        res = s[1] * np.log(s[2] / s[1]) - s[0]
+        if res > 0:
+            return True
+    return False
 
-    kernel = @cuda launch=false _kernel_compute_barrier_pow(barrier,z,s,dz,ds,α,αp,rng_cones,n_shift,n_pow)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_pow, config.threads)
-    blocks = cld(n_pow, threads)
+@njit
+def is_dual_feasible_pow(z, α):
+    if z[2] > 0 and z[0] < 0:
+        res = z[1] - z[0] - z[0] * np.log(-z[2] / z[0])
+        if res > 0:
+            return True
+    return False
 
-    CUDA.@sync kernel(barrier,z,s,dz,ds,α,αp,rng_cones,n_shift,n_pow; threads, blocks)
+@njit
+def gradient_primal_pow(s, α):
+    ω = _wright_omega(1 - s[0] / s[1] - np.log(s[1] / s[2]))
+    g1 = 1 / ((ω - 1) * s[1])
+    g2 = g1 + g1 * np.log(ω * s[1] / s[2]) - 1 / s[1]
+    g3 = ω / ((1 - ω) * s[2])
+    return np.array([g1, g2, g3])
 
-    return sum(@view barrier[1:n_pow])
-end
+@njit
+def higher_correction_pow(H, z, η, ds, v, α):
+    u = np.linalg.solve(H, ds)
+    η[1] = 1
+    η[2] = -z[0] / z[2]
+    η[0] = np.log(η[2])
+    ψ = z[0] * η[0] - z[0] + z[1]
+    dotψu = np.dot(η, u)
+    dotψv = np.dot(η, v)
+    coef = ((u[0] * (v[0] / z[0] - v[2] / z[2]) + u[2] * (z[0] * v[2] / z[2] - v[0]) / z[2]) * ψ - 2 * dotψu * dotψv) / (ψ * ψ * ψ)
+    η *= coef
+    inv_ψ2 = 1 / (ψ * ψ)
+    η[0] += (1 / ψ - 2 / z[0]) * u[0] * v[0] / (z[0] * z[0]) - u[2] * v[2] / (z[2] * z[2]) / ψ + dotψu * inv_ψ2 * (v[0] / z[0] - v[2] / z[2]) + dotψv * inv_ψ2 * (u[0] / z[0] - u[2] / z[2])
+    η[2] += 2 * (z[0] / ψ - 1) * u[2] * v[2] / (z[2] * z[2] * z[2]) - (u[2] * v[0] + u[0] * v[2]) / (z[2] * z[2]) / ψ + dotψu * inv_ψ2 * (z[0] * v[2] / (z[2] * z[2]) - v[0] / z[2]) + dotψv * inv_ψ2 * (z[0] * u[2] / (z[2] * z[2]) - u[0] / z[2])
+    η /= 2
 
+@njit
+def update_dual_grad_H_pow(grad, H, z, α):
+    l = np.log(-z[2] / z[0])
+    r = -z[0] * l - z[0] + z[1]
+    c2 = 1 / r
+    grad[0] = c2 * l - 1 / z[0]
+    grad[1] = -c2
+    grad[2] = (c2 * z[0] - 1) / z[2]
+    H[0, 0] = ((r * r - z[0] * r + l * l * z[0] * z[0]) / (r * z[0] * z[0] * r))
+    H[0, 1] = (-l / (r * r))
+    H[1, 0] = H[0, 1]
+    H[1, 1] = (1 / (r * r))
+    H[0, 2] = ((z[1] - z[0]) / (r * r * z[2]))
+    H[2, 0] = H[0, 2]
+    H[1, 2] = (-z[0] / (r * r * z[2]))
+    H[2, 1] = H[1, 2]
+    H[2, 2] = ((r * r - z[0] * r + z[0] * z[0]) / (r * r * z[2] * z[2]))
 
-# # ----------------------------------------------
-# #  nonsymmetric cone operations for power cones
-# #
-# # Primal Power cone: s1^{α}s2^{1-α} ≥ s3, s1,s2 ≥ 0
-# # Dual Power cone: (z1/α)^{α} * (z2/(1-α))^{1-α} ≥ z3, z1,z2 ≥ 0
-# # We use the dual barrier function: 
-# # f*(z) = -log((z1/α)^{2α} * (z2/(1-α))^{2(1-α)} - z3*z3) - (1-α)*log(z1) - α*log(z2):
-# # Evaluates the gradient of the dual Power cone ∇f*(z) at z, 
-# # and stores the result at g
-
-
-@inline function barrier_dual_pow(
-    z::AbstractVector{T}, 
-    α::T
-) where {T}
-
-    # Dual barrier
-    return -logsafe((z[1]/α)^(2*α) * (z[2]/(1-α))^(2-2*α) - z[3]*z[3]) - (1-α)*logsafe(z[1]) - α*logsafe(z[2])
-
-end
-
-@inline function barrier_primal_pow(
-    s::AbstractVector{T}, 
-    α::T
-) where {T}
-
-    # Primal barrier: f(s) = ⟨s,g(s)⟩ - f*(-g(s))
-    # NB: ⟨s,g(s)⟩ = -3 = - ν
-
-    g = gradient_primal_pow(s, α)     #compute g(s)
-    return logsafe((-g[1]/α)^(2*α) * (-g[2]/(1-α))^(2-2*α) - g[3]*g[3]) + (1-α)*logsafe(-g[1]) + α*logsafe(-g[2]) - 3
-end 
-
-
-
-# Returns true if s is primal feasible
-@inline function is_primal_feasible_pow(
-    s::AbstractVector{T}, 
-    α::T
-) where {T}
-
-    if (s[1] > 0 && s[2] > 0)
-        res = exp(2*α*logsafe(s[1]) + 2*(1-α)*logsafe(s[2])) - s[3]*s[3]
-        if res > 0
-            return true
-        end
-    end
-
-    return false
-end
-
-# Returns true if s is dual feasible
-@inline function is_dual_feasible_pow(
-    z::AbstractVector{T}, 
-    α::T
-) where {T}
-
-    if (z[1] > 0 && z[2] > 0)
-        res = exp(2*α*logsafe(z[1]/α) + 2*(1-α)*logsafe(z[2]/(1-α))) - z[3]*z[3]
-        if res > 0
-            return true
-        end
-    end
-
-    return false
-end
-
-# Compute the primal gradient of f(s) at s
-# solve it by the Newton-Raphson method
-function gradient_primal_pow(
-    s::Union{AbstractVector{T}, NTuple{3,T}},
-    α::T
-) where {T}
-
-    # unscaled ϕ
-    ϕ = (s[1])^(2*α)*(s[2])^(2-2*α)
-    g = @MVector T[0, 0, 0]
-
-
-    # obtain g3 from the Newton-Raphson method
-    abs_s = abs(s[3])
-    if abs_s > eps(T)
-        g[3] = _newton_raphson_powcone(abs_s,ϕ,α)
-        if s[3] < zero(T)
-            g[3] = -g[3]
-        end
-        g[1] = -(α*g[3]*s[3] + 1 + α)/s[1]
-        g[2] = -((1-α)*g[3]*s[3] + 2 - α)/s[2]
-    else
-        g[3] = zero(T)
-        g[1] = -(1+α)/s[1]
-        g[2] = -(2-α)/s[2]
-    end
-    return SVector(g)
-
-end
-
-
-# 3rd-order correction at the point z.  Output is η.
-
-# 3rd order correction: 
-# η = -0.5*[(dot(u,Hψ,v)*ψ - 2*dotψu*dotψv)/(ψ*ψ*ψ)*gψ + 
-#            dotψu/(ψ*ψ)*Hψv + dotψv/(ψ*ψ)*Hψu - 
-#            dotψuv/ψ + dothuv]
-# where: 
-# Hψ = [  2*α*(2*α-1)*ϕ/(z1*z1)     4*α*(1-α)*ϕ/(z1*z2)       0;
-#         4*α*(1-α)*ϕ/(z1*z2)     2*(1-α)*(1-2*α)*ϕ/(z2*z2)   0;
-#         0                       0                          -2;]
-@inline function higher_correction_pow!(
-    H::AbstractArray{T},
-    z::AbstractVector{T},
-    η::AbstractVector{T},
-    ds::AbstractVector{T},
-    v::AbstractVector{T},
-    α::T
-) where {T}
-
-    #solve H*u = ds
-    cholH = @MArray T[0.0 0.0 0.0;0.0 0.0 0.0;0.0 0.0 0.0]
-    issuccess = cholesky_3x3_explicit_factor!(cholH,H)
-    if issuccess 
-        u = cholesky_3x3_explicit_solve!(cholH,ds)
-    else 
-        return SVector(zero(T),zero(T),zero(T))
-    end
-
-    ϕ = (z[1]/α)^(2*α)*(z[2]/(1-α))^(2-2*α)
-    ψ = ϕ - z[3]*z[3]
-
-    # Reuse cholH memory for further computation
-    Hψ = cholH
-    
-    η[1] = 2*α*ϕ/z[1]
-    η[2] = 2*(1-α)*ϕ/z[2]
-    η[3] = -2*z[3]
-
-    Hψ[1,1] = 2*α*(2*α-1)*ϕ/(z[1]*z[1])
-    Hψ[1,2] = 4*α*(1-α)*ϕ/(z[1]*z[2])
-    Hψ[2,1] = Hψ[1,2]
-    Hψ[1,3] = 0
-    Hψ[3,1] = 0
-    Hψ[2,2] = 2*(1-α)*(1-2*α)*ϕ/(z[2]*z[2])
-    Hψ[2,3] = 0
-    Hψ[3,2] = 0
-    Hψ[3,3] = -2.
-
-    dotψu = _dot_xy_gpu(η,u,1:3)
-    dotψv = _dot_xy_gpu(η,v,1:3)
-
-    Hψv = @MVector T[0, 0, 0]
-    Hψv[1] = Hψ[1,1]*v[1]+Hψ[1,2]*v[2]
-    Hψv[2] = Hψ[2,1]*v[1]+Hψ[2,2]*v[2]
-    Hψv[3] = -2*v[3]
-
-    coef = (_dot_xy_gpu(u,Hψv,1:3)*ψ - 2*dotψu*dotψv)/(ψ*ψ*ψ)
-    coef2 = 4*α*(2*α-1)*(1-α)*ϕ*(u[1]/z[1] - u[2]/z[2])*(v[1]/z[1] - v[2]/z[2])/ψ
-    inv_ψ2 = 1/ψ/ψ
-
-    η[1] = coef*η[1] - 2*(1-α)*u[1]*v[1]/(z[1]*z[1]*z[1]) + 
-           coef2/z[1] + Hψv[1]*dotψu*inv_ψ2
-
-    η[2] = coef*η[2] - 2*α*u[2]*v[2]/(z[2]*z[2]*z[2]) - 
-           coef2/z[2] + Hψv[2]*dotψu*inv_ψ2
-
-    η[3] = coef*η[3] + Hψv[3]*dotψu*inv_ψ2
-
-    # reuse vector Hψv
-    Hψu = Hψv
-    Hψu[1] = Hψ[1,1]*u[1]+Hψ[1,2]*u[2]
-    Hψu[2] = Hψ[2,1]*u[1]+Hψ[2,2]*u[2]
-    Hψu[3] = -2*u[3]
-
-    # @. η <= (η + Hψu*dotψv*inv_ψ2)/2
-    @inbounds for i = 1:3
-        η[i] = (η[i] + Hψu[i]*dotψv*inv_ψ2)/2
-    end
-    # coercing to an SArray means that the MArray we computed 
-    # locally in this function is seemingly not heap allocated 
-    SVector(η)
-end
-
-
-# update gradient and Hessian at dual z
-function update_dual_grad_H_pow(
-    grad::AbstractVector{T},
-    H::AbstractArray{T},
-    z::AbstractVector{T},
-    α::T
-) where {T}
-
-    ϕ = (z[1]/α)^(2*α)*(z[2]/(1-α))^(2-2*α)
-    ψ = ϕ - z[3]*z[3]
-
-    # use K.grad as a temporary workspace
-    gψ = grad
-    gψ[1] = 2*α*ϕ/(z[1]*ψ)
-    gψ[2] = 2*(1-α)*ϕ/(z[2]*ψ)
-    gψ[3] = -2*z[3]/ψ
-
-    H[1,1] = gψ[1]*gψ[1] - 2*α*(2*α-1)*ϕ/(z[1]*z[1]*ψ) + (1-α)/(z[1]*z[1])
-    H[1,2] = gψ[1]*gψ[2] - 4*α*(1-α)*ϕ/(z[1]*z[2]*ψ)
-    H[2,1] = H[1,2]
-    H[2,2] = gψ[2]*gψ[2] - 2*(1-α)*(1-2*α)*ϕ/(z[2]*z[2]*ψ) + α/(z[2]*z[2])
-    H[1,3] = gψ[1]*gψ[3]
-    H[3,1] = H[1,3]
-    H[2,3] = gψ[2]*gψ[3]
-    H[3,2] = H[2,3]
-    H[3,3] = gψ[3]*gψ[3] + 2/ψ
-
-    # compute the gradient at z
-    grad[1] = -2*α*ϕ/(z[1]*ψ) - (1-α)/z[1]
-    grad[2] = -2*(1-α)*ϕ/(z[2]*ψ) - α/z[2]
-    grad[3] = 2*z[3]/ψ
-end
-
-
-# # Newton-Raphson method:
-# # solve a one-dimensional equation f(x) = 0
-# # x(k+1) = x(k) - f(x(k))/f'(x(k))
-# # When we initialize x0 such that 0 < x0 < x*, 
-# # the Newton-Raphson method converges quadratically
-
-# function _newton_raphson_powcone(
-#     s3::T,
-#     ϕ::T,
-#     α::T
-# ) where {T}
-
-#     # init point x0: f(x0) > 0
-#     x0 = -one(T)/s3 + (2*s3 + sqrt(ϕ*ϕ/s3/s3 + 3*ϕ))/(ϕ - s3*s3)
-
-#     # additional shift due to the choice of dual barrier
-#     t0 = - 2*α*logsafe(α) - 2*(1-α)*logsafe(1-α)   
-
-#     # function for f(x) = 0
-#     function f0(x)
-#         t1 = x*x; t2 = 2*x/s3;
-#         2*α*logsafe(2*α*t1 + (1+α)*t2) + 
-#              2*(1-α)*logsafe(2*(1-α)*t1 + (2-α)*t2) - 
-#              logsafe(ϕ) - logsafe(t1+t2) - 
-#              2*logsafe(t2) + t0
-#     end
-
-#     # first derivative
-#     function f1(x)
-#         t1 = x*x; t2 = x*2/s3;
-#         2*α*α/(α*x + (1+α)/s3) + 2*(1-α)*(1-α)/((1-α)*x + 
-#              (2-α)/s3) - 2*(x + 1/s3)/(t1 + t2)
-#     end
-    
-#      return _newton_raphson_onesided(x0,f0,f1)
-# end
+@njit
+def _wright_omega(z):
+    if z < 0:
+        return np.inf
+    if z < 1 + np.pi:
+        zm1 = z - 1
+        p = zm1
+        w = 1 + 0.5 * p
+        p *= zm1
+        w += (1 / 16.0) * p
+        p *= zm1
+        w -= (1 / 192.0) * p
+        p *= zm1
+        w -= (1 / 3072.0) * p
+        p *= zm1
+        w += (13 / 61440.0) * p
+    else:
+        logz = np.log(z)
+        zinv = 1 / z
+        w = z - logz
+        q = logz * zinv
+        w += q
+        q *= zinv
+        w += q * (logz / 2 - 1)
+        q *= zinv
+        w += q * (logz * logz / 3.0 - (3 / 2.0) * logz + 1)
+    r = z - w - np.log(w)
+    for _ in range(2):
+        wp1 = w + 1
+        t = wp1 * (wp1 + (2 * r) / 3.0)
+        w *= 1 + (r / wp1) * (t - 0.5 * r) / (t - r)
+        r = (2 * w * w - 8 * w - 1) / (72.0 * (wp1 * wp1 * wp1 * wp1 * wp1 * wp1)) * r * r * r * r
+    return w

--- a/src/gpucones/coneops_socone_gpu.jl
+++ b/src/gpucones/coneops_socone_gpu.jl
@@ -1,952 +1,347 @@
-# # ----------------------------------------------------
-# # Second Order Cone
-# # ----------------------------------------------------
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
 
-# #degree = 1 for SOC, since e'*e = 1
-# degree(K::SecondOrderCone{T}) where {T} = 1
-# numel(K::SecondOrderCone{T}) where {T} = K.dim
-
-# function is_sparse_expandable(K::SecondOrderCone{T}) where{T}
-#     return !isnothing(K.sparse_data)
-# end
-
-function _kernel_margins_soc(
-    z::AbstractVector{T},
-    α::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where{T}
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_margins_soc(z, α, rng_cones, n_shift, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_shift
         rng_cone_i = rng_cones[shift_i]
-        size_i = length(rng_cone_i)
-        @views zi = z[rng_cone_i] 
-        
-        val = zero(T)
-        @inbounds for j in 2:size_i 
-            val += zi[j]*zi[j]
-        end
-        α[i]  = zi[1] - sqrt(val)
-    end
+        size_i = len(rng_cone_i)
+        zi = z[rng_cone_i]
+        val = 0.0
+        for j in range(1, size_i):
+            val += zi[j] * zi[j]
+        α[i] = zi[0] - np.sqrt(val)
 
-    return nothing
-end
+def margins_soc(z, α, rng_cones, n_shift, n_soc, αmin):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_margins_soc[blocks_per_grid, threads_per_block](z, α, rng_cones, n_shift, n_soc)
+    αsoc = α[:n_soc]
+    αmin = min(αmin, np.min(αsoc))
+    αsoc = cp.maximum(0, αsoc)
+    return αmin, cp.sum(αsoc)
 
-@inline function margins_soc(
-    z::AbstractVector{T},
-    α::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint,
-    αmin::T
-) where{T}
-    kernel = @cuda launch=false _kernel_margins_soc(z, α, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(z, α, rng_cones, n_shift, n_soc; threads, blocks)
-
-    @views αsoc = α[1:n_soc]
-    αmin = min(αmin,minimum(αsoc))
-    CUDA.@sync @. αsoc = max(zero(T),αsoc)
-    return (αmin, sum(αsoc))
-end
-
-# place vector into socone
-function _kernel_scaled_unit_shift_soc!(
-    z::AbstractVector{T},
-    α::T,
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where{T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_scaled_unit_shift_soc(z, α, rng_cones, n_shift, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_shift
         rng_cone_i = rng_cones[shift_i]
-        @views zi = z[rng_cone_i] 
-        zi[1] += α
-    end
+        zi = z[rng_cone_i]
+        zi[0] += α
 
-    return nothing
-end
+def scaled_unit_shift_soc(z, rng_cones, α, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_scaled_unit_shift_soc[blocks_per_grid, threads_per_block](z, α, rng_cones, n_shift, n_soc)
 
-@inline function scaled_unit_shift_soc!(
-    z::AbstractVector{T},
-    rng_cones::AbstractVector,
-    α::T,
-    n_shift::Cint,
-    n_soc::Cint   
-) where{T}
-
-    kernel = @cuda launch=false _kernel_scaled_unit_shift_soc!(z, α, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(z, α, rng_cones, n_shift, n_soc; threads, blocks)
-end
-
-# unit initialization for asymmetric solves
-function _kernel_unit_initialization_soc!(
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint
-) where{T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_unit_initialization_soc(z, s, rng_cones, n_linear, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
-        @views zi = z[rng_cone_i] 
-        @views si = s[rng_cone_i] 
-        zi[1] = one(T)
-        @inbounds for j in 2:length(zi)
-            zi[j] = zero(T)
-        end
+        zi = z[rng_cone_i]
+        si = s[rng_cone_i]
+        zi[0] = 1.0
+        for j in range(1, len(zi)):
+            zi[j] = 0.0
+        si[0] = 1.0
+        for j in range(1, len(si)):
+            si[j] = 0.0
 
-        si[1] = one(T)
-        @inbounds for j in 2:length(si)
-            si[j] = zero(T)
-        end
-    end
- 
-    return nothing
-end 
+def unit_initialization_soc(z, s, rng_cones, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_unit_initialization_soc[blocks_per_grid, threads_per_block](z, s, rng_cones, n_shift, n_soc)
 
-@inline function unit_initialization_soc!(
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where{T}
-
-    kernel = @cuda launch=false _kernel_unit_initialization_soc!(z, s, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(z, s, rng_cones, n_shift, n_soc; threads, blocks)
-end 
-
-# # configure cone internals to provide W = I scaling
-function _kernel_set_identity_scaling_soc!(
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_set_identity_scaling_soc(w, η, rng_cones, n_linear, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
-        size_i = length(rng_cone_i)
-        @views wi = w[rng_cone_i] 
-        wi[1] = one(T)
-        @inbounds for j in 2:size_i 
-            wi[j] = zero(T)
-        end
-        η[i]  = one(T)
+        size_i = len(rng_cone_i)
+        wi = w[rng_cone_i]
+        wi[0] = 1.0
+        for j in range(1, size_i):
+            wi[j] = 0.0
+        η[i] = 1.0
 
-        # YC: no augmented sparse cone at the moment
-        # if !isnothing(K.sparse_data)
-        #     K.sparse_data.d  = T(0.5)
-        #     K.sparse_data.u .= zero(T)
-        #     K.sparse_data.u[1] = sqrt(T(0.5))
-        #     K.sparse_data.v .= zero(T)
-        # end 
-    end
+def set_identity_scaling_soc(w, η, rng_cones, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_set_identity_scaling_soc[blocks_per_grid, threads_per_block](w, η, rng_cones, n_shift, n_soc)
 
-    return nothing
-end
-
-@inline function set_identity_scaling_soc!(
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-    kernel = @cuda launch=false _kernel_set_identity_scaling_soc!(w, η, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(w, η, rng_cones, n_shift, n_soc; threads, blocks)
-end
-
-function _kernel_update_scaling_soc!(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    w::AbstractVector{T},
-    λ::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_update_scaling_soc(s, z, w, λ, η, rng_cones, n_shift, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_shift
         rng_i = rng_cones[shift_i]
-        @views zi = z[rng_i] 
-        @views si = s[rng_i] 
-        @views wi = w[rng_i] 
-        @views λi = λ[rng_i]
-
-        #first calculate the scaled vector w
-        @views zscale = _sqrt_soc_residual_gpu(zi)
-        @views sscale = _sqrt_soc_residual_gpu(si)
-
-        #the leading scalar term for W^TW
-        η[i] = sqrt(sscale/zscale)
-
-        # construct w and normalize
-        @inbounds for k in rng_i
-            w[k] = s[k]/(sscale)
-        end
-
-        wi[1]  += zi[1]/(zscale)
-
-        @inbounds for j in 2:length(wi)
-            wi[j] -= zi[j]/(zscale)
-        end
-    
+        zi = z[rng_i]
+        si = s[rng_i]
+        wi = w[rng_i]
+        λi = λ[rng_i]
+        zscale = _sqrt_soc_residual_gpu(zi)
+        sscale = _sqrt_soc_residual_gpu(si)
+        η[i] = np.sqrt(sscale / zscale)
+        for k in range(len(rng_i)):
+            w[k] = si[k] / sscale
+        wi[0] += zi[0] / zscale
+        for j in range(1, len(wi)):
+            wi[j] -= zi[j] / zscale
         wscale = _sqrt_soc_residual_gpu(wi)
-        wi ./= wscale
-
-        #try to force badly scaled w to come out normalized
-        w1sq = zero(T)
-        @inbounds for j in 2:length(wi)
-            w1sq += wi[j]*wi[j]
-        end
-        wi[1] = sqrt(1 + w1sq)
-
-        #Compute the scaling point λ.   Should satisfy λ = Wz = W^{-T}s
+        wi /= wscale
+        w1sq = 0.0
+        for j in range(1, len(wi)):
+            w1sq += wi[j] * wi[j]
+        wi[0] = np.sqrt(1 + w1sq)
         γi = 0.5 * wscale
-        λi[1] = γi 
+        λi[0] = γi
+        coef = 1 / (si[0] / sscale + zi[0] / zscale + 2 * γi)
+        c1 = (γi + zi[0] / zscale) / sscale
+        c2 = (γi + si[0] / sscale) / zscale
+        for j in range(1, len(λi)):
+            λi[j] = coef * (c1 * si[j] + c2 * zi[j])
+        λi *= np.sqrt(sscale * zscale)
 
-        coef = inv(si[1]/sscale + zi[1]/zscale + 2*γi)
-        c1 = ((γi + zi[1]/zscale)/sscale)
-        c2 = ((γi + si[1]/sscale)/zscale)
-        @inbounds for j in 2:length(λi)
-            λi[j] = coef*(c1*si[j] +c2*zi[j])
-        end
-        λi .*= sqrt(sscale*zscale)
-    end
+def update_scaling_soc(s, z, w, λ, η, rng_cones, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_update_scaling_soc[blocks_per_grid, threads_per_block](s, z, w, λ, η, rng_cones, n_shift, n_soc)
 
-    return nothing
-
-    #YC: don't support sparse SOC currently
-    # #Populate sparse expansion terms if allocated
-    # if is_sparse_expandable(K)
-
-    #     sparse_data = K.sparse_data
-
-    #     #various intermediate calcs for u,v,d
-    #     α  = 2*w[1]
-
-    #     #Scalar d is the upper LH corner of the diagonal
-    #     #term in the rank-2 update form of W^TW
-    #     wsq    = w[1]*w[1] + w1sq
-    #     wsqinv = 1/wsq
-    #     sparse_data.d    = wsqinv / 2
-
-    #     #the vectors for the rank two update
-    #     #representation of W^TW
-    #     u0  = sqrt(wsq - sparse_data.d)
-    #     u1 = α/u0
-    #     v0 = zero(T)
-    #     v1 = sqrt( 2*(2 + wsqinv)/(2*wsq - wsqinv))
-        
-    #     sparse_data.u[1] = u0
-    #     @views K.sparse_data.u[2:end] .= u1.*w[2:end]
-    #     sparse_data.v[1] = v0
-    #     @views sparse_data.v[2:end] .= v1.*w[2:end]
-
-    # end 
-
-    # return is_scaling_success = true
-end
-
-@inline function update_scaling_soc!(
-    s::AbstractVector{T},
-    z::AbstractVector{T},
-    w::AbstractVector{T},
-    λ::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_update_scaling_soc!(s, z, w, λ, η, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(s, z, w, λ, η, rng_cones, n_shift, n_soc; threads, blocks)
-end
-
-function _kernel_get_Hs_soc!(
-    Hsblocks::AbstractVector{T},
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    rng_blocks::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_get_Hs_soc(Hsblocks, w, η, rng_cones, rng_blocks, n_linear, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
         rng_block_i = rng_blocks[shift_i]
-        size_i = length(rng_cone_i)
-        @views wi = w[rng_cone_i] 
-        @views Hsblocki = Hsblocks[rng_block_i]
-
-        hidx = one(Cint)
-        @inbounds for col in rng_cone_i
-            wcol = w[col]
-            @inbounds for row in rng_cone_i
-                Hsblocki[hidx] = 2*w[row]*wcol
+        size_i = len(rng_cone_i)
+        wi = w[rng_cone_i]
+        Hsblocki = Hsblocks[rng_block_i]
+        hidx = 0
+        for col in range(size_i):
+            wcol = wi[col]
+            for row in range(size_i):
+                Hsblocki[hidx] = 2 * wi[row] * wcol
                 hidx += 1
-            end 
-        end
-        Hsblocki[1] -= one(T)
-        @inbounds for ind in 2:size_i
-            Hsblocki[(ind-1)*size_i + ind] += one(T)
-        end
-        Hsblocki .*= η[i]^2
-    end
+        Hsblocki[0] -= 1.0
+        for ind in range(1, size_i):
+            Hsblocki[(ind - 1) * size_i + ind] += 1.0
+        Hsblocki *= η[i] ** 2
 
-    return nothing
-end
+def get_Hs_soc(Hsblocks, w, η, rng_cones, rng_blocks, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_get_Hs_soc[blocks_per_grid, threads_per_block](Hsblocks, w, η, rng_cones, rng_blocks, n_shift, n_soc)
 
-@inline function get_Hs_soc!(
-    Hsblocks::AbstractVector{T},
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    rng_blocks::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-
-    #YC: don't support sparse SOC currently
-    # if is_sparse_expandable(K)
-    #     #For sparse form, we are returning here the diagonal D block 
-    #     #from the sparse representation of W^TW, but not the
-    #     #extra two entries at the bottom right of the block.
-    #     #The AbstractVector for s and z (and its views) don't
-    #     #know anything about the 2 extra sparsifying entries
-    #     Hsblock    .= K.η^2
-    #     Hsblock[1] *= K.sparse_data.d
-    # end
-
-    kernel = @cuda launch=false _kernel_get_Hs_soc!(Hsblocks, w, η, rng_cones, rng_blocks, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(Hsblocks, w, η, rng_cones, rng_blocks, n_shift, n_soc; threads, blocks)
-
-end
-
-# function Hs_is_diagonal(
-#     K::SecondOrderCone{T}
-# ) where{T}
-#     return is_sparse_expandable(K)
-# end
-
-# compute the product y = WᵀWx
-function _kernel_mul_Hs_soc!(
-    y::AbstractVector{T},
-    x::AbstractVector{T},
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint
-) where {T}
-
-    # y = = H^{-1}x = W^TWx
-    # where H^{-1} = \eta^{2} (2*ww^T - J)
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_mul_Hs_soc(y, x, w, η, rng_cones, n_linear, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
-        size_i = length(rng_cone_i)
-        @views xi = x[rng_cone_i] 
-        @views yi = y[rng_cone_i] 
-        @views wi = w[rng_cone_i] 
+        size_i = len(rng_cone_i)
+        xi = x[rng_cone_i]
+        yi = y[rng_cone_i]
+        wi = w[rng_cone_i]
+        c = 2 * _dot_xy_gpu(wi, xi, size_i)
+        yi[0] = -xi[0] + c * wi[0]
+        for j in range(1, size_i):
+            yi[j] = xi[j] + c * wi[j]
+        yi *= η[i] ** 2
 
-        c = 2*_dot_xy_gpu(wi,xi,1:size_i)
+def mul_Hs_soc(y, x, w, η, rng_cones, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_mul_Hs_soc[blocks_per_grid, threads_per_block](y, x, w, η, rng_cones, n_shift, n_soc)
 
-        yi[1] = -xi[1] + c*wi[1]
-        @inbounds for j in 2:size_i
-            yi[j] = xi[j] + c*wi[j]
-        end
-
-        _multiply_gpu(yi,η[i]^2)
-    end
-
-    return nothing
-end
-
-@inline function mul_Hs_soc!(
-    y::AbstractVector{T},
-    x::AbstractVector{T},
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_mul_Hs_soc!(y, x, w, η, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(y, x, w, η, rng_cones, n_shift, n_soc; threads, blocks)
-end
-
-# returns x = λ ∘ λ for the socone
-function _kernel_affine_ds_soc!(
-    ds::AbstractVector{T},
-    λ::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_affine_ds_soc(ds, λ, rng_cones, n_linear, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
-        size_i = length(rng_cone_i)
-        @views dsi = ds[rng_cone_i] 
-        @views λi = λ[rng_cone_i] 
+        size_i = len(rng_cone_i)
+        dsi = ds[rng_cone_i]
+        λi = λ[rng_cone_i]
+        dsi[0] = 0.0
+        for j in range(size_i):
+            dsi[0] += λi[j] * λi[j]
+        λi0 = λi[0]
+        for j in range(1, size_i):
+            dsi[j] = 2 * λi0 * λi[j]
 
-        #circ product λ∘λ
-        dsi[1] = zero(T)
-        for j in 1:length(dsi)
-            dsi[1] += λi[j]*λi[j]
-        end
-        λi0 = λi[1]
-        for j = 2:length(dsi)
-            dsi[j] = 2*λi0*λi[j]
-        end
-      
-    end
+def affine_ds_soc(ds, λ, rng_cones, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_affine_ds_soc[blocks_per_grid, threads_per_block](ds, λ, rng_cones, n_shift, n_soc)
 
-    return nothing
-
-end
-
-@inline function affine_ds_soc!(
-    ds::AbstractVector{T},
-    λ::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_affine_ds_soc!(ds, λ, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(ds, λ, rng_cones, n_shift, n_soc; threads, blocks)
-end
-
-function _kernel_combined_ds_shift_soc!(
-    shift::AbstractVector{T},
-    step_z::AbstractVector{T},
-    step_s::AbstractVector{T},
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint,
-    σμ::T
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_combined_ds_shift_soc(shift, step_z, step_s, w, η, rng_cones, n_linear, n_soc, σμ):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
-        size_i = length(rng_cone_i)
-        @views step_zi = step_z[rng_cone_i] 
-        @views step_si = step_s[rng_cone_i] 
-        @views wi = w[rng_cone_i] 
-        @views shifti = shift[rng_cone_i] 
-    
-        #shift vector used as workspace for a few steps 
-        tmp = shifti            
-
-        #Δz <- WΔz
-        @inbounds for j in 1:size_i
+        size_i = len(rng_cone_i)
+        step_zi = step_z[rng_cone_i]
+        step_si = step_s[rng_cone_i]
+        wi = w[rng_cone_i]
+        shifti = shift[rng_cone_i]
+        tmp = shifti.copy()
+        for j in range(size_i):
             tmp[j] = step_zi[j]
-        end         
-        ζ = zero(T)
-        
-        @inbounds for j in 2:size_i
-            ζ += wi[j]*tmp[j]
-        end
-
-        c = tmp[1] + ζ/(1+wi[1])
-      
-        step_zi[1] = η[i]*(wi[1]*tmp[1] + ζ)
-      
-        @inbounds for j in 2:size_i
-            step_zi[j] = η[i]*(tmp[j] + c*wi[j]) 
-        end      
-
-        #Δs <- W⁻¹Δs
-        @inbounds for j in 1:size_i
+        ζ = 0.0
+        for j in range(1, size_i):
+            ζ += wi[j] * tmp[j]
+        c = tmp[0] + ζ / (1 + wi[0])
+        step_zi[0] = η[i] * (wi[0] * tmp[0] + ζ)
+        for j in range(1, size_i):
+            step_zi[j] = η[i] * (tmp[j] + c * wi[j])
+        for j in range(size_i):
             tmp[j] = step_si[j]
-        end           
-        ζ = zero(T)
-        @inbounds for j in 2:size_i
-            ζ += wi[j]*tmp[j]
-        end
+        ζ = 0.0
+        for j in range(1, size_i):
+            ζ += wi[j] * tmp[j]
+        c = -tmp[0] + ζ / (1 + wi[0])
+        step_si[0] = (1 / η[i]) * (wi[0] * tmp[0] - ζ)
+        for j in range(1, size_i):
+            step_si[j] = (1 / η[i]) * (tmp[j] + c * wi[j])
+        val = 0.0
+        for j in range(size_i):
+            val += step_si[j] * step_zi[j]
+        shifti[0] = val - σμ
+        s0 = step_si[0]
+        z0 = step_zi[0]
+        for j in range(1, size_i):
+            shifti[j] = s0 * step_zi[j] + z0 * step_si[j]
 
-        c = -tmp[1] + ζ/(1+wi[1])
-    
-        step_si[1] = (one(T)/η[i])*(wi[1]*tmp[1] - ζ)
-    
-        @inbounds for j = 2:size_i
-            step_si[j] = (one(T)/η[i])*(tmp[j] + c*wi[j])
-        end
+def combined_ds_shift_soc(shift, step_z, step_s, w, η, rng_cones, n_shift, n_soc, σμ):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_combined_ds_shift_soc[blocks_per_grid, threads_per_block](shift, step_z, step_s, w, η, rng_cones, n_shift, n_soc, σμ)
 
-        #shift = W⁻¹Δs ∘ WΔz - σμe  
-        val = zero(T)
-        @inbounds for j in 1:size_i
-            val += step_si[j]*step_zi[j]
-        end       
-        shifti[1] = val - σμ 
-
-        s0   = step_si[1]
-        z0   = step_zi[1]
-        for j = 2:size_i
-            shifti[j] = s0*step_zi[j] + z0*step_si[j]
-        end      
-    end                    
-
-    return nothing
-end
-
-@inline function combined_ds_shift_soc!(
-    shift::AbstractVector{T},
-    step_z::AbstractVector{T},
-    step_s::AbstractVector{T},
-    w::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint,
-    σμ::T
-) where {T}
-
-    kernel = @cuda launch=false _kernel_combined_ds_shift_soc!(shift, step_z, step_s, w, η, rng_cones, n_shift, n_soc, σμ)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(shift, step_z, step_s, w, η, rng_cones, n_shift, n_soc, σμ; threads, blocks)
-end
-
-function _kernel_Δs_from_Δz_offset_soc!(
-    out::AbstractVector{T},
-    ds::AbstractVector{T},
-    z::AbstractVector{T},
-    w::AbstractVector{T},
-    λ::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_Δs_from_Δz_offset_soc(out, ds, z, w, λ, η, rng_cones, n_shift, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_shift
         rng_cone_i = rng_cones[shift_i]
-        size_i = length(rng_cone_i)
-        @views outi = out[rng_cone_i] 
-        @views dsi = ds[rng_cone_i] 
-        @views zi = z[rng_cone_i] 
-        @views wi = w[rng_cone_i] 
-        @views λi = λ[rng_cone_i] 
-
-        #out = Wᵀ(λ \ ds).  Below is equivalent,
-        #but appears to be a little more stable 
+        size_i = len(rng_cone_i)
+        outi = out[rng_cone_i]
+        dsi = ds[rng_cone_i]
+        zi = z[rng_cone_i]
+        wi = w[rng_cone_i]
+        λi = λ[rng_cone_i]
         reszi = _soc_residual_gpu(zi)
+        λ1ds1 = _dot_xy_gpu(λi, dsi, size_i)
+        w1ds1 = _dot_xy_gpu(wi, dsi, size_i)
+        _minus_vec_gpu(outi, zi)
+        outi[0] = zi[0]
+        c = λi[0] * dsi[0] - λ1ds1
+        _multiply_gpu(outi, c / reszi)
+        outi[0] += η[i] * w1ds1
+        for j in range(1, size_i):
+            outi[j] += η[i] * (dsi[j] + w1ds1 / (1 + wi[0]) * wi[j])
+        _multiply_gpu(outi, 1 / λi[0])
 
-        @views λ1ds1  = _dot_xy_gpu(λi,dsi,2:size_i)
-        @views w1ds1  = _dot_xy_gpu(wi,dsi,2:size_i)
+def Δs_from_Δz_offset_soc(out, ds, z, w, λ, η, rng_cones, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_Δs_from_Δz_offset_soc[blocks_per_grid, threads_per_block](out, ds, z, w, λ, η, rng_cones, n_shift, n_soc)
 
-        _minus_vec_gpu(outi,zi)
-        outi[1] = +zi[1]
-    
-        c = λi[1]*dsi[1] - λ1ds1
-        _multiply_gpu(outi,c/reszi)
-
-        outi[1] += η[i]*w1ds1
-        @inbounds for j in 2:size_i
-            outi[j] += η[i]*(dsi[j] + w1ds1/(1+wi[1])*wi[j])
-        end
-    
-        _multiply_gpu(outi,one(T)/λi[1])
-    end
-
-    return nothing
-
-end
-
-@inline function Δs_from_Δz_offset_soc!(
-    out::AbstractVector{T},
-    ds::AbstractVector{T},
-    z::AbstractVector{T},
-    w::AbstractVector{T},
-    λ::AbstractVector{T},
-    η::AbstractVector{T},
-    rng_cones::AbstractVector,
-    n_shift::Cint,
-    n_soc::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_Δs_from_Δz_offset_soc!(out, ds, z, w, λ, η, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(out, ds, z, w, λ, η, rng_cones, n_shift, n_soc; threads, blocks)
-end
-
-#return maximum allowable step length while remaining in the socone
-function _kernel_step_length_soc(
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-     z::AbstractVector{T},
-     s::AbstractVector{T},
-     α::AbstractVector{T},
-     rng_cones::AbstractVector,
-     n_linear::Cint,
-     n_soc::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_step_length_soc(dz, ds, z, s, α, rng_cones, n_linear, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
-        @views si = s[rng_cone_i] 
-        @views dsi = ds[rng_cone_i] 
-        @views zi = z[rng_cone_i] 
-        @views dzi = dz[rng_cone_i]         
+        si = s[rng_cone_i]
+        dsi = ds[rng_cone_i]
+        zi = z[rng_cone_i]
+        dzi = dz[rng_cone_i]
+        αz = _step_length_soc_component_gpu(zi, dzi, α[i])
+        αs = _step_length_soc_component_gpu(si, dsi, α[i])
+        α[i] = min(αz, αs)
 
-        αz   = _step_length_soc_component_gpu(zi,dzi,α[i])
-        αs   = _step_length_soc_component_gpu(si,dsi,α[i])
-        α[i] = min(αz,αs)
-    end
-
-    return nothing
-end
-
-@inline function step_length_soc(
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-     z::AbstractVector{T},
-     s::AbstractVector{T},
-     α::AbstractVector{T},
-     αmax::T,
-     rng_cones::AbstractVector,
-     n_shift::Cint,
-     n_soc::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_step_length_soc(dz, ds, z, s, α, rng_cones, n_shift, n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(dz, ds, z, s, α, rng_cones, n_shift, n_soc; threads, blocks)
-    @views αmax = min(αmax,minimum(α[1:n_soc]))
-
+def step_length_soc(dz, ds, z, s, α, αmax, rng_cones, n_shift, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_step_length_soc[blocks_per_grid, threads_per_block](dz, ds, z, s, α, rng_cones, n_shift, n_soc)
+    αmax = min(αmax, np.min(α[:n_soc]))
     return αmax
-end
 
-function _kernel_compute_barrier_soc(
-    barrier::AbstractVector{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-    α::T,
-    rng_cones::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint
-) where {T}
-
-    i = (blockIdx().x-1)*blockDim().x+threadIdx().x
-
-    if i <= n_soc
+@cuda.jit
+def _kernel_compute_barrier_soc(barrier, z, s, dz, ds, α, rng_cones, n_linear, n_soc):
+    i = cuda.grid(1)
+    if i < n_soc:
         shift_i = i + n_linear
         rng_cone_i = rng_cones[shift_i]
-        @views si = s[rng_cone_i] 
-        @views dsi = ds[rng_cone_i] 
-        @views zi = z[rng_cone_i] 
-        @views dzi = dz[rng_cone_i]  
-        res_si = _soc_residual_shifted(si,dsi,α)
-        res_zi = _soc_residual_shifted(zi,dzi,α)
+        si = s[rng_cone_i]
+        dsi = ds[rng_cone_i]
+        zi = z[rng_cone_i]
+        dzi = dz[rng_cone_i]
+        res_si = _soc_residual_shifted(si, dsi, α)
+        res_zi = _soc_residual_shifted(zi, dzi, α)
+        barrier[i] = -np.log(res_si * res_zi) / 2 if res_si > 0 and res_zi > 0 else np.inf
 
-        # avoid numerical issue if res_s <= 0 or res_z <= 0
-        barrier[i] = (res_si > 0 && res_zi > 0) ? -logsafe(res_si*res_zi)/2 : Inf
-    end
+def compute_barrier_soc(barrier, z, s, dz, ds, α, rng_cones, n_linear, n_soc):
+    threads_per_block = 128
+    blocks_per_grid = (n_soc + (threads_per_block - 1)) // threads_per_block
+    _kernel_compute_barrier_soc[blocks_per_grid, threads_per_block](barrier, z, s, dz, ds, α, rng_cones, n_linear, n_soc)
+    return np.sum(barrier[:n_soc])
 
-    return nothing
-end
-
-@inline function compute_barrier_soc(
-    barrier::AbstractVector{T},
-    z::AbstractVector{T},
-    s::AbstractVector{T},
-    dz::AbstractVector{T},
-    ds::AbstractVector{T},
-    α::T,
-    rng_cones::AbstractVector,
-    n_linear::Cint,
-    n_soc::Cint
-) where {T}
-
-    kernel = @cuda launch=false _kernel_compute_barrier_soc(barrier,z,s,dz,ds,α,rng_cones,n_linear,n_soc)
-    config = launch_configuration(kernel.fun)
-    threads = min(n_soc, config.threads)
-    blocks = cld(n_soc, threads)
-
-    CUDA.@sync kernel(barrier,z,s,dz,ds,α,rng_cones,n_linear,n_soc; threads, blocks)
-
-    return sum(barrier[1:n_soc])
-end
-
-# # ---------------------------------------------
-# # operations supported by symmetric cones only 
-# # ---------------------------------------------
-
-
-# # implements y = αWx + βy for the socone
-# function mul_W!(
-#     K::SecondOrderCone{T},
-#     is_transpose::Symbol,
-#     y::AbstractVector{T},
-#     x::AbstractVector{T},
-#     α::T,
-#     β::T
-# ) where {T}
-
-#   #NB: symmetric, so ignore transpose
-
-#   # use the fast product method from ECOS ECC paper
-#   @views ζ = dot(K.w[2:end],x[2:end])
-#   c = x[1] + ζ/(1+K.w[1])
-
-#   y[1] = α*K.η*(K.w[1]*x[1] + ζ) + β*y[1]
-
-#   @inbounds for i in 2:length(y)
-#       y[i] = α*K.η*(x[i] + c*K.w[i]) + β*y[i]
-#   end
-
-#   return nothing
-# end
-
-# # implements y = αW^{-1}x + βy for the socone
-# function mul_Winv!(
-#     K::SecondOrderCone{T},
-#     is_transpose::Symbol,
-#     y::AbstractVector{T},
-#     x::AbstractVector{T},
-#     α::T,
-#     β::T
-# ) where {T}
-
-#     #NB: symmetric, so ignore transpose
-
-#     # use the fast inverse product method from ECOS ECC paper
-#     @views ζ = dot(K.w[2:end],x[2:end])
-#     c = -x[1] + ζ/(1+K.w[1])
-
-#     y[1] = (α/K.η)*(K.w[1]*x[1] - ζ) + β*y[1]
-
-#     @inbounds for i = 2:length(y)
-#         y[i] = (α/K.η)*(x[i] + c*K.w[i]) + β*y[i]
-#     end
-
-#     return nothing
-# end
-
-# # implements x = λ \ z for the socone, where λ
-# # is the internally maintained scaling variable.
-# function λ_inv_circ_op!(
-#     K::SecondOrderCone{T},
-#     x::AbstractVector{T},
-#     z::AbstractVector{T}
-# ) where {T}
-
-#     inv_circ_op!(K, x, K.λ, z)
-
-# end
-
-# ---------------------------------------------
-# Jordan algebra operations for symmetric cones 
-# ---------------------------------------------
-
-# # implements x = y \ z for the socone
-# function inv_circ_op!(
-#     K::SecondOrderCone{T},
-#     x::AbstractVector{T},
-#     y::AbstractVector{T},
-#     z::AbstractVector{T}
-# ) where {T}
-
-#     p = _soc_residual(y)
-#     pinv = 1/p
-#     @views v = dot(y[2:end],z[2:end])
-
-#     x[1]      = (y[1]*z[1] - v)*pinv
-#     @views x[2:end] .= pinv.*(v/y[1] - z[1]).*y[2:end] + (1/y[1]).*z[2:end]
-
-#     return nothing
-# end
-
-# ---------------------------------------------
-# internal operations for second order cones 
-# ---------------------------------------------
-
-@inline function _soc_residual_gpu(z::AbstractVector{T}) where {T} 
-    res = z[1]*z[1]
-    for j in 2:length(z)
-        res -= z[j]*z[j]
-    end
-    
+@njit
+def _soc_residual_gpu(z):
+    res = z[0] * z[0]
+    for j in range(1, len(z)):
+        res -= z[j] * z[j]
     return res
-end 
 
-@inline function _sqrt_soc_residual_gpu(z::AbstractVector{T}) where {T} 
+@njit
+def _sqrt_soc_residual_gpu(z):
     res = _soc_residual_gpu(z)
-    
-    # set res to 0 when z is not an interior point
-    res = res > 0.0 ? sqrt(res) : zero(T)
-end 
+    return np.sqrt(res) if res > 0 else 0.0
 
-@inline function _dot_xy_gpu(x::AbstractVector{T},y::AbstractVector{T},rng::UnitRange) where {T} 
-    val = zero(T)
-    for j in rng
-        val += x[j]*y[j]
-    end
-    
+@njit
+def _dot_xy_gpu(x, y, size):
+    val = 0.0
+    for j in range(size):
+        val += x[j] * y[j]
     return val
-end 
 
-@inline function _minus_vec_gpu(y::AbstractVector{T},x::AbstractVector{T}) where {T} 
-    @inbounds for j in 1:length(x)
+@njit
+def _minus_vec_gpu(y, x):
+    for j in range(len(x)):
         y[j] = -x[j]
-    end
-end 
 
-@inline function _multiply_gpu(x::AbstractVector{T},a::T) where {T} 
-    @inbounds for j in 1:length(x)
-        x[j] *= a 
-    end
-end 
+@njit
+def _multiply_gpu(x, a):
+    for j in range(len(x)):
+        x[j] *= a
 
-# find the maximum step length α≥0 so that
-# x + αy stays in the SOC
-@inline function _step_length_soc_component_gpu(
-    x::AbstractVector{T},
-    y::AbstractVector{T},
-    αmax::T
-) where {T}
-
-    # assume that x is in the SOC, and find the minimum positive root
-    # of the quadratic equation:  ||x₁+αy₁||^2 = (x₀ + αy₀)^2
-
-    @views a = _soc_residual_gpu(y) #NB: could be negative
-    @views b = 2*(x[1]*y[1] - _dot_xy_gpu(x,y,2:length(x)))
-    @views c = max(zero(T),_soc_residual_gpu(x)) #should be ≥0
-    d = b^2 - 4*a*c
-
-    if(c < 0)
-        # This should never be reachable since c ≥ 0 above
-        return -Inf
-    end
-
-    if( (a > 0 && b > 0) || d < 0)
-        #all negative roots / complex root pair
-        #-> infinite step length
+@njit
+def _step_length_soc_component_gpu(x, y, αmax):
+    a = _soc_residual_gpu(y)
+    b = 2 * (x[0] * y[0] - _dot_xy_gpu(x, y, len(x)))
+    c = max(0.0, _soc_residual_gpu(x))
+    d = b * b - 4 * a * c
+    if c < 0:
+        return -np.inf
+    if (a > 0 and b > 0) or d < 0:
         return αmax
-
-    elseif a == 0
-        #edge case with only one root.  This corresponds to
-        #the case where the search direction is exactly on the 
-        #cone boundary.   The root should be -c/b, but b can't 
-        #be negative since both (x,y) are in the cone and it is 
-        #self dual, so <x,y> \ge 0 necessarily.
+    if a == 0:
         return αmax
-
-    elseif c == 0
-        #Edge case with one of the roots at 0.   This corresponds 
-        #to the case where the initial point is exactly on the 
-        #cone boundary.  The other root is -b/a.   If the search 
-        #direction is in the cone, then a >= 0 and b can't be 
-        #negative due to self-duality.  If a < 0, then the 
-        #direction is outside the cone and b can't be positive.
-        #Either way, step length is determined by whether or not 
-        #the search direction is in the cone.
-
-        return (a >= 0 ? αmax : zero(T)) 
-    end 
-
-
-    # if we got this far then we need to calculate a pair 
-    # of real roots and choose the smallest positive one.  
-    # We need to be cautious about cancellations though.  
-    # See §1.4: Goldberg, ACM Computing Surveys, 1991 
-    # https://dl.acm.org/doi/pdf/10.1145/103162.103163
-
-    t = (b >= 0) ? (-b - sqrt(d)) : (-b + sqrt(d))
-
-    r1 = (2*c)/t;
-    r2 = t/(2*a);
-
-    #return the minimum positive root, up to αmax
-    r1 = r1 < 0 ? floatmax(T) : r1
-    r2 = r2 < 0 ? floatmax(T) : r2
-
-    return min(αmax,r1,r2)
-
-end
+    if c == 0:
+        return αmax if a >= 0 else 0.0
+    t = (-b - np.sqrt(d)) if b >= 0 else (-b + np.sqrt(d))
+    r1 = (2 * c) / t
+    r2 = t / (2 * a)
+    r1 = np.finfo(np.float64).max if r1 < 0 else r1
+    r2 = np.finfo(np.float64).max if r2 < 0 else r2
+    return min(αmax, r1, r2)

--- a/src/kktsolvers/gpu/directgpu_datamaps.jl
+++ b/src/kktsolvers/gpu/directgpu_datamaps.jl
@@ -1,284 +1,151 @@
-using SparseArrays, StaticArrays
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
 
-abstract type SparseExpansionFullMap end 
+class SparseExpansionFullMap:
+    pass
 
-pdim(maps::Vector{SparseExpansionFullMap}) = sum(pdim, maps; init = 0)
-nnz_vec(maps::Vector{SparseExpansionFullMap}) = sum(nnz_vec, maps; init = 0)
+def pdim(maps):
+    return sum(pdim(map) for map in maps)
 
-struct SOCExpansionFullMap <: SparseExpansionFullMap
-    u::Vector{Int}        #off diag dense columns u
-    v::Vector{Int}        #off diag dense columns v
-    ut::Vector{Int}        #off diag dense columns ut
-    vt::Vector{Int}        #off diag dense columns vt
-    D::MVector{2, Int}    #diag D
-    function SOCExpansionFullMap(cone::SecondOrderCone)
-        u = Vector{Int}(undef,numel(cone))
-        v = Vector{Int}(undef,numel(cone))
-        ut = Vector{Int}(undef,numel(cone))
-        vt = Vector{Int}(undef,numel(cone))
-        D = MVector(0,0)
-        new(u,v,ut,vt,D)
-    end
-end
-pdim(::SOCExpansionFullMap) = 2
-nnz_vec(map::SOCExpansionFullMap) = 4*length(map.u)
-Dsigns(::SOCExpansionFullMap) = (-1,1)
-expansion_fullmap(cone::SecondOrderCone) = SOCExpansionFullMap(cone)
+def nnz_vec(maps):
+    return sum(nnz_vec(map) for map in maps)
 
-function _csc_colcount_sparsecone_full(
-    cone::SecondOrderCone,
-    map::SOCExpansionFullMap,
-    K::SparseMatrixCSC,
-    row::Int,col::Int
-)
-    
-    nvars = numel(cone)
+class SOCExpansionFullMap(SparseExpansionFullMap):
+    def __init__(self, cone):
+        self.u = cp.empty(cone.numel(), dtype=np.int32)
+        self.v = cp.empty(cone.numel(), dtype=np.int32)
+        self.ut = cp.empty(cone.numel(), dtype=np.int32)
+        self.vt = cp.empty(cone.numel(), dtype=np.int32)
+        self.D = cp.zeros(2, dtype=np.int32)
 
-    _csc_colcount_colvec(K,nvars,row, col  ) #v column
-    _csc_colcount_colvec(K,nvars,row, col+1) #u column
-    _csc_colcount_rowvec(K,nvars,col,   row) #v row
-    _csc_colcount_rowvec(K,nvars,col+1, row) #u row
+def pdim_SOCExpansionFullMap(map):
+    return 2
 
-    _csc_colcount_diag(K,col,pdim(map))
-end
+def nnz_vec_SOCExpansionFullMap(map):
+    return 4 * len(map.u)
 
-function _csc_fill_sparsecone_full(
-    cone::SecondOrderCone,
-    map::SOCExpansionFullMap,
-    K::SparseMatrixCSC,row::Int,col::Int
-)
+def Dsigns_SOCExpansionFullMap(map):
+    return (-1, 1)
 
-    #fill structural zeros for u and v columns for this cone
-    #note v is the first extra row/column, u is second
-    #fill columns
-    _csc_fill_colvec(K, map.v, row, col    ) #v
-    _csc_fill_colvec(K, map.u, row, col + 1) #u
-    #fill rows
-    _csc_fill_rowvec(K, map.vt, col    , row) #vt
-    _csc_fill_rowvec(K, map.ut, col + 1, row) #ut
+def expansion_fullmap_SOCExpansionFullMap(cone):
+    return SOCExpansionFullMap(cone)
 
-    _csc_fill_diag(K,map.D,col,pdim(map))
-end 
+@njit
+def _csc_colcount_sparsecone_full_SOCExpansionFullMap(cone, map, K, row, col):
+    nvars = cone.numel()
+    _csc_colcount_colvec(K, nvars, row, col)
+    _csc_colcount_colvec(K, nvars, row, col + 1)
+    _csc_colcount_rowvec(K, nvars, col, row)
+    _csc_colcount_rowvec(K, nvars, col + 1, row)
+    _csc_colcount_diag(K, col, pdim_SOCExpansionFullMap(map))
 
-function _csc_update_sparsecone_full(
-    cone::SecondOrderCone{T},
-    map::SOCExpansionFullMap, 
-    updateFcn, 
-    scaleFcn
-) where {T}
-    
-    η2 = cone.η^2
+@njit
+def _csc_fill_sparsecone_full_SOCExpansionFullMap(cone, map, K, row, col):
+    _csc_fill_colvec(K, map.v, row, col)
+    _csc_fill_colvec(K, map.u, row, col + 1)
+    _csc_fill_rowvec(K, map.vt, col, row)
+    _csc_fill_rowvec(K, map.ut, col + 1, row)
+    _csc_fill_diag(K, map.D, col, pdim_SOCExpansionFullMap(map))
 
-    #off diagonal columns (or rows)
-    updateFcn(map.u,cone.sparse_data.u)
-    updateFcn(map.v,cone.sparse_data.v)
-    updateFcn(map.ut,cone.sparse_data.u)
-    updateFcn(map.vt,cone.sparse_data.v)
-    scaleFcn(map.u,-η2)
-    scaleFcn(map.v,-η2)
-    scaleFcn(map.ut,-η2)
-    scaleFcn(map.vt,-η2)
+@njit
+def _csc_update_sparsecone_full_SOCExpansionFullMap(cone, map, updateFcn, scaleFcn):
+    η2 = cone.η**2
+    updateFcn(map.u, cone.sparse_data.u)
+    updateFcn(map.v, cone.sparse_data.v)
+    updateFcn(map.ut, cone.sparse_data.u)
+    updateFcn(map.vt, cone.sparse_data.v)
+    scaleFcn(map.u, -η2)
+    scaleFcn(map.v, -η2)
+    scaleFcn(map.ut, -η2)
+    scaleFcn(map.vt, -η2)
+    updateFcn(map.D, [-η2, +η2])
 
-    #set diagonal to η^2*(-1,1) in the extended rows/cols
-    updateFcn(map.D,[-η2,+η2])
+class GenPowExpansionFullMap(SparseExpansionFullMap):
+    def __init__(self, cone):
+        self.p = cp.empty(cone.numel(), dtype=np.int32)
+        self.q = cp.empty(cone.dim1(), dtype=np.int32)
+        self.r = cp.empty(cone.dim2(), dtype=np.int32)
+        self.pt = cp.empty(cone.numel(), dtype=np.int32)
+        self.qt = cp.empty(cone.dim1(), dtype=np.int32)
+        self.rt = cp.empty(cone.dim2(), dtype=np.int32)
+        self.D = cp.zeros(3, dtype=np.int32)
 
-end
+def pdim_GenPowExpansionFullMap(map):
+    return 3
 
-struct GenPowExpansionFullMap <: SparseExpansionFullMap
-    
-    p::Vector{Int}        #off diag dense columns p
-    q::Vector{Int}        #off diag dense columns q
-    r::Vector{Int}        #off diag dense columns r
-    pt::Vector{Int}        #off diag dense rows pt
-    qt::Vector{Int}        #off diag dense rows qt
-    rt::Vector{Int}        #off diag dense rows rt
-    D::MVector{3, Int}    #diag D
+def nnz_vec_GenPowExpansionFullMap(map):
+    return (len(map.p) + len(map.q) + len(map.r)) * 2
 
-    function GenPowExpansionFullMap(cone::GenPowerCone)
-        p = Vector{Int}(undef,numel(cone))
-        q = Vector{Int}(undef,dim1(cone))
-        r = Vector{Int}(undef,dim2(cone))
-        pt = Vector{Int}(undef,numel(cone))
-        qt = Vector{Int}(undef,dim1(cone))
-        rt = Vector{Int}(undef,dim2(cone))
-        D = MVector(0,0,0)
-        new(p,q,r,pt,qt,rt,D)
-    end
-end
-pdim(::GenPowExpansionFullMap) = 3
-nnz_vec(map::GenPowExpansionFullMap) = (length(map.p) + length(map.q) + length(map.r))<<1
-Dsigns(::GenPowExpansionFullMap) = (-1,-1,+1)
-expansion_fullmap(cone::GenPowerCone) = GenPowExpansionFullMap(cone)
+def Dsigns_GenPowExpansionFullMap(map):
+    return (-1, -1, +1)
 
-function _csc_colcount_sparsecone_full(
-    cone::GenPowerCone,
-    map::GenPowExpansionFullMap,
-    K::SparseMatrixCSC,row::Int,col::Int
-)
+def expansion_fullmap_GenPowExpansionFullMap(cone):
+    return GenPowExpansionFullMap(cone)
 
-    nvars   = numel(cone)
-    dim1 = Clarabel.dim1(cone)
-    dim2 = Clarabel.dim2(cone)
+@njit
+def _csc_colcount_sparsecone_full_GenPowExpansionFullMap(cone, map, K, row, col):
+    nvars = cone.numel()
+    dim1 = cone.dim1()
+    dim2 = cone.dim2()
+    _csc_colcount_colvec(K, dim1, row, col)
+    _csc_colcount_colvec(K, dim2, row + dim1, col + 1)
+    _csc_colcount_colvec(K, nvars, row, col + 2)
+    _csc_colcount_rowvec(K, dim1, col, row)
+    _csc_colcount_rowvec(K, dim2, col + 1, row + dim1)
+    _csc_colcount_rowvec(K, nvars, col + 2, row)
+    _csc_colcount_diag(K, col, pdim_GenPowExpansionFullMap(map))
 
-    _csc_colcount_colvec(K,dim1, row,        col)    #q column
-    _csc_colcount_colvec(K,dim2, row + dim1, col+1)  #r column
-    _csc_colcount_colvec(K,nvars,row,        col+2)  #p column
+@njit
+def _csc_fill_sparsecone_full_GenPowExpansionFullMap(cone, map, K, row, col):
+    dim1 = cone.dim1()
+    _csc_fill_colvec(K, map.q, row, col)
+    _csc_fill_colvec(K, map.r, row + dim1, col + 1)
+    _csc_fill_colvec(K, map.p, row, col + 2)
+    _csc_fill_rowvec(K, map.qt, col, row)
+    _csc_fill_rowvec(K, map.rt, col + 1, row + dim1)
+    _csc_fill_rowvec(K, map.pt, col + 2, row)
+    _csc_fill_diag(K, map.D, col, pdim_GenPowExpansionFullMap(map))
 
-    _csc_colcount_rowvec(K,dim1, col,   row)         #qt row
-    _csc_colcount_rowvec(K,dim2, col+1, row + dim1)  #rt row
-    _csc_colcount_rowvec(K,nvars,col+2, row)         #pt row
+@njit
+def _csc_update_sparsecone_full_GenPowExpansionFullMap(cone, map, updateFcn, scaleFcn):
+    data = cone.data
+    sqrtμ = np.sqrt(data.μ)
+    updateFcn(map.q, data.q)
+    updateFcn(map.r, data.r)
+    updateFcn(map.p, data.p)
+    updateFcn(map.qt, data.q)
+    updateFcn(map.rt, data.r)
+    updateFcn(map.pt, data.p)
+    scaleFcn(map.q, -sqrtμ)
+    scaleFcn(map.r, -sqrtμ)
+    scaleFcn(map.p, -sqrtμ)
+    scaleFcn(map.qt, -sqrtμ)
+    scaleFcn(map.rt, -sqrtμ)
+    scaleFcn(map.pt, -sqrtμ)
+    updateFcn(map.D, [-1, -1, 1])
 
-    _csc_colcount_diag(K,col,pdim(map))
-    
-end
+class FullDataMap:
+    def __init__(self, Pmat, Amat, cones):
+        m, n = Amat.shape
+        self.P = cp.zeros(Pmat.nnz, dtype=np.int32)
+        self.A = cp.zeros(Amat.nnz, dtype=np.int32)
+        self.At = cp.zeros(Amat.nnz, dtype=np.int32)
+        self.diagP = cp.zeros(n, dtype=np.int32)
+        self.Hsblocks = _allocate_kkt_Hsblocks(np.int32, cones)
+        nsparse = sum(1 for cone in cones if cone.is_sparse_expandable())
+        self.sparse_maps = []
+        for cone in cones:
+            if cone.is_sparse_expandable():
+                self.sparse_maps.append(expansion_fullmap_GenPowExpansionFullMap(cone))
+        self.diag_full = cp.zeros(m + n + pdim(self.sparse_maps), dtype=np.int32)
 
-function _csc_fill_sparsecone_full(
-    cone::GenPowerCone{T},
-    map::GenPowExpansionFullMap,
-    K::SparseMatrixCSC{T},
-    row::Int,col::Int
-) where{T}
-
-    dim1  = Clarabel.dim1(cone)
-
-    _csc_fill_colvec(K, map.q, row,        col)   #q
-    _csc_fill_colvec(K, map.r, row + dim1, col+1) #r 
-    _csc_fill_colvec(K, map.p, row,        col+2) #p 
-
-    _csc_fill_rowvec(K, map.qt, col,   row)        #qt
-    _csc_fill_rowvec(K, map.rt, col+1, row + dim1) #rt
-    _csc_fill_rowvec(K, map.pt, col+2, row)        #pt
-
-    _csc_fill_diag(K,map.D,col,pdim(map))
-
-end 
-
-function _csc_update_sparsecone_full(
-    cone::GenPowerCone{T},
-    map::GenPowExpansionFullMap, 
-    updateFcn, 
-    scaleFcn
-) where {T}
-    
-    data  = cone.data
-    sqrtμ = sqrt(data.μ)
-
-    #off diagonal columns (rows), distribute √μ to off-diagonal terms
-    updateFcn(map.q,data.q)
-    updateFcn(map.r,data.r)
-    updateFcn(map.p,data.p)
-    updateFcn(map.qt,data.q)
-    updateFcn(map.rt,data.r)
-    updateFcn(map.pt,data.p)
-    scaleFcn(map.q,-sqrtμ)
-    scaleFcn(map.r,-sqrtμ)
-    scaleFcn(map.p,-sqrtμ)
-    scaleFcn(map.qt,-sqrtμ)
-    scaleFcn(map.rt,-sqrtμ)
-    scaleFcn(map.pt,-sqrtμ)
-
-    #normalize diagonal terms to 1/-1 in the extended rows/cols
-    updateFcn(map.D,[-one(T),-one(T),one(T)])
-    
-end
-
-
-struct FullDataMap
-
-    P::Vector{Int}
-    A::Vector{Int}
-    At::Vector{Int}        #YC: not sure whether we need it or not
-    Hsblocks::Vector{Int}                #indices of the lower RHS blocks (by cone)
-    sparse_maps::Vector{SparseExpansionFullMap}      #sparse cone expansion terms
-
-    #all of above terms should be disjoint and their union
-    #should cover all of the user data in the KKT matrix.  Now
-    #we make two last redundant indices that will tell us where
-    #the whole diagonal is, including structural zeros.
-    diagP::Vector{Int}
-    diag_full::Vector{Int}
-
-    function FullDataMap(Pmat::SparseMatrixCSC{T},Amat::SparseMatrixCSC{T},cones) where{T}
-
-        (m,n) = (size(Amat,1), size(Pmat,1))
-        P = zeros(Int,nnz(Pmat))
-        A = zeros(Int,nnz(Amat))
-        At = zeros(Int,nnz(Amat))
-
-        #the diagonal of the ULHS block P.
-        #NB : we fill in structural zeros here even if the matrix
-        #P is empty (e.g. as in an LP), so we can have entries in
-        #index Pdiag that are not present in the index P
-        diagP  = zeros(Int,n)
-
-        #make an index for each of the Hs blocks for each cone
-        Hsblocks = _allocate_kkt_Hsblocks(Int, cones)
-
-        #now do the sparse cone expansion pieces
-        nsparse = count(cone->(@conedispatch is_sparse_expandable(cone)),cones)
-        sparse_maps = Vector{SparseExpansionFullMap}(); 
-        sizehint!(sparse_maps,nsparse)
-
-        for cone in cones
-            if @conedispatch is_sparse_expandable(cone) 
-                push!(sparse_maps,expansion_fullmap(cone))
-            end
-        end
-
-        diag_full = zeros(Int,m+n+pdim(sparse_maps))
-
-        return new(P,A,At,Hsblocks,sparse_maps,diagP,diag_full)
-    end
-
-end
-
-struct GPUDataMap
-
-    P::AbstractVector{Cint}
-    A::AbstractVector{Cint}
-    At::AbstractVector{Cint}        #YC: not sure whether we need it or not
-    Hsblocks::AbstractVector{Cint}                #indices of the lower RHS blocks (by cone)
-    # sparse_maps::Vector{SparseExpansionFullMap}      #YC: disabled sparse cone expansion terms
-
-    #all of above terms should be disjoint and their union
-    #should cover all of the user data in the KKT matrix.  Now
-    #we make two last redundant indices that will tell us where
-    #the whole diagonal is, including structural zeros.
-    diagP::AbstractVector{Cint}
-    diag_full::AbstractVector{Cint}
-
-    function GPUDataMap(Pmat::SparseMatrixCSC{T},Amat::SparseMatrixCSC{T},cones,mapcpu::FullDataMap) where{T}
-
-        (m,n) = (size(Amat,1), size(Pmat,1))
-        P = isempty(mapcpu.P) ? CUDA.zeros(Int,0) : unsafe_wrap(CuArray,mapcpu.P)
-        A = isempty(mapcpu.A) ? CUDA.zeros(Int,0) : unsafe_wrap(CuArray,mapcpu.A)
-        At = isempty(mapcpu.At) ? CUDA.zeros(Int,0) : unsafe_wrap(CuArray,mapcpu.At)
-
-        #the diagonal of the ULHS block P.
-        #NB : we fill in structural zeros here even if the matrix
-        #P is empty (e.g. as in an LP), so we can have entries in
-        #index Pdiag that are not present in the index P
-        diagP  = unsafe_wrap(CuArray,mapcpu.diagP)
-
-        #make an index for each of the Hs blocks for each cone
-        Hsblocks = CuVector{Cint}(mapcpu.Hsblocks)
-
-        #YC: disable sparse cone expansion at present
-        # #now do the sparse cone expansion pieces
-        # nsparse = count(cone->(@conedispatch is_sparse_expandable(cone)),cones)
-        # sparse_maps = Vector{SparseExpansionFullMap}(); 
-        # sizehint!(sparse_maps,nsparse)
-
-        # for cone in cones
-        #     if @conedispatch is_sparse_expandable(cone) 
-        #         push!(sparse_maps,expansion_fullmap(cone))
-        #     end
-        # end
-
-        # diag_full = zeros(Int,m+n+pdim(sparse_maps))
-        diag_full = unsafe_wrap(CuArray,mapcpu.diag_full)
-
-        return new(P,A,At,Hsblocks,diagP,diag_full)
-    end
-
-end
+class GPUDataMap:
+    def __init__(self, Pmat, Amat, cones, mapcpu):
+        m, n = Amat.shape
+        self.P = cp.zeros(0, dtype=np.int32) if mapcpu.P.size == 0 else cp.asarray(mapcpu.P)
+        self.A = cp.zeros(0, dtype=np.int32) if mapcpu.A.size == 0 else cp.asarray(mapcpu.A)
+        self.At = cp.zeros(0, dtype=np.int32) if mapcpu.At.size == 0 else cp.asarray(mapcpu.At)
+        self.diagP = cp.asarray(mapcpu.diagP)
+        self.Hsblocks = cp.asarray(mapcpu.Hsblocks)
+        self.diag_full = cp.asarray(mapcpu.diag_full)

--- a/src/kktsolvers/gpu/directldl_cudss.jl
+++ b/src/kktsolvers/gpu/directldl_cudss.jl
@@ -1,60 +1,24 @@
-using CUDA, CUDA.CUSPARSE
-using CUDSS
+import cupy as cp
+import numpy as np
+from numba import cuda, njit
+from cudss import CudssSolver, cudss, cudss_set, ldiv
 
-export CUDSSDirectLDLSolver
-struct CUDSSDirectLDLSolver{T} <: AbstractGPUSolver{T}
+class CUDSSDirectLDLSolver:
+    def __init__(self, KKT, x, b):
+        self.KKTgpu = KKT
+        self.cudssSolver = CudssSolver(KKT, "S", 'F')
+        cudss("analysis", self.cudssSolver, x, b)
+        cudss("factorization", self.cudssSolver, x, b)
+        self.x = x
+        self.b = b
 
-    KKTgpu::AbstractSparseMatrix{T}
-    cudssSolver::CUDSS.CudssSolver{T}
-    x::AbstractVector{T}
-    b::AbstractVector{T}
-    
+def required_matrix_shape():
+    return 'full'
 
-    function CUDSSDirectLDLSolver{T}(KKT::AbstractSparseMatrix{T},x,b) where {T}
-
-        dim = LinearAlgebra.checksquare(KKT)
-
-        #make a logical factorization to fix memory allocations
-        # "S" denotes real symmetric and 'U' denotes the upper triangular
-
-        KKTgpu = KKT
-        cudssSolver = CUDSS.CudssSolver(KKTgpu, "S", 'F')
-
-        cudss("analysis", cudssSolver, x, b)
-        cudss("factorization", cudssSolver, x, b)
-
-        return new(KKTgpu,cudssSolver,x,b)
-    end
-
-end
-
-GPUSolversDict[:cudss] = CUDSSDirectLDLSolver
-required_matrix_shape(::Type{CUDSSDirectLDLSolver}) = :full
-
-#refactor the linear system
-function refactor!(ldlsolver::CUDSSDirectLDLSolver{T}) where{T}
-
-    # Update the KKT matrix in the cudss solver
-    cudss_set(ldlsolver.cudssSolver.matrix,ldlsolver.KKTgpu)
-
-    # Refactorization
+def refactor(ldlsolver):
+    cudss_set(ldlsolver.cudssSolver.matrix, ldlsolver.KKTgpu)
     cudss("factorization", ldlsolver.cudssSolver, ldlsolver.x, ldlsolver.b)
+    return True
 
-    # YC: should be corrected later on 
-    return true
-    # return all(isfinite, cudss_get(ldlsolver.cudssSolver.data,"diag"))
-
-end
-
-
-#solve the linear system
-function solve!(
-    ldlsolver::CUDSSDirectLDLSolver{T},
-    x::AbstractVector{T},
-    b::AbstractVector{T}
-) where{T}
-    
-    #solve on GPU
-    ldiv!(x,ldlsolver.cudssSolver,b)
-
-end
+def solve(ldlsolver, x, b):
+    ldiv(x, ldlsolver.cudssSolver, b)


### PR DESCRIPTION
Convert the existing Julia code to Python, ensuring high performance, correctness, readability, and modularity.

* **General Changes**
  - Replace Julia imports with equivalent Python imports.
  - Replace Julia constants and type definitions with Python equivalents.
  - Replace Julia functions with Python functions using `@njit` for JIT compilation where applicable.
  - Replace Julia array and matrix operations with equivalent NumPy and SciPy operations.
  - Replace Julia module structure with Python class structure where applicable.

* **File: `src/Clarabel.jl`**
  - Replace Julia imports with Python imports.
  - Define constants and type definitions in Python.
  - Convert internal constraint RHS limits to Python functions.
  - Define GPU solver list in Python.
  - Comment out include statements for other modules.

* **File: `src/gpucones/augment_socp.jl`**
  - Replace Julia imports with Python imports.
  - Convert functions `count_soc`, `augment_data`, `augment_A_b_soc`, and `expand_soc` to Python using `@njit` for JIT compilation.
  - Replace Julia array and matrix operations with equivalent NumPy and SciPy operations.

* **File: `src/gpucones/compositecone_type_gpu.jl`**
  - Replace Julia imports with Python imports.
  - Convert `CompositeConeGPU` struct to a Python class.
  - Define class methods for initialization, indexing, and iteration.
  - Replace Julia array and matrix operations with equivalent NumPy and CuPy operations.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cvxgrp/CuClarabel/pull/16?shareId=3ca4e5a6-5acb-4202-88b9-99ea61ec860d).